### PR TITLE
chore: add CI workflow and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+<!-- Thanks for contributing to Astro Fleet! Please fill in the sections below. -->
+
+## Summary
+
+<!-- 1–3 sentences on what this PR changes and why. -->
+
+## Screenshots
+
+<!-- If this PR touches UI, drop before/after screenshots here. Delete this section for non-UI PRs. -->
+
+## Test plan
+
+<!-- Check each item as you verify it. -->
+
+- [ ] `bun install` runs cleanly
+- [ ] `bun run build` succeeds for every affected site
+- [ ] Local dev server renders the change correctly
+- [ ] Mobile / responsive behaviour verified (if UI)
+- [ ] No new TypeScript errors
+
+## Notes for reviewers
+
+<!-- Anything that needs context, tradeoffs, or follow-up work. Delete if not needed. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build all sites
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build all sites
+        run: bun run build


### PR DESCRIPTION
## Summary

Adds two pieces of repo hygiene that should exist on any serious open-source project:

1. **GitHub Actions CI** — builds every site on every push to \`main\` and every PR. Locks us out of broken merges and shows contributors the bar.
2. **Pull request template** — prefills new PRs with Summary / Screenshots / Test plan / Notes sections so every contribution lands in a consistent shape.

## What's in the CI workflow

- Runs on \`push\` to \`main\` and on every \`pull_request\` targeting \`main\`
- Uses \`oven-sh/setup-bun@v2\` — Bun is the canonical package manager for this repo
- Installs with \`bun install --frozen-lockfile\` to catch lockfile drift
- Builds every site via \`bun run build\` (Turborepo parallelises and caches)
- \`concurrency\` block cancels superseded runs when a PR is force-pushed
- 10-minute timeout as a safety net

No secrets, no third-party actions beyond \`actions/checkout@v4\` and \`oven-sh/setup-bun@v2\`, no \`write\` permissions — minimal attack surface.

## Verified locally

\`\`\`
bun install --frozen-lockfile → no changes
bun run build                → 4 successful, 4 cached (47ms with Turbo cache)
\`\`\`

## Test plan

- [x] \`bun install --frozen-lockfile\` runs cleanly locally
- [x] \`bun run build\` succeeds for all four workspaces (starter + three demos)
- [ ] GitHub Actions CI shows green on this PR
- [ ] PR template appears in the "Files changed" view of future PRs

The second two items can only be verified once this PR is open — will update once the Actions run completes.