### PR TITLE
docs: add framework integrations guide and Astro capabilities reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,5 +101,6 @@ For in-depth guidance beyond what's in this file, refer to:
 - [docs/getting-started.md](docs/getting-started.md) — Clone to first deploy in 15 minutes
 - [docs/adding-a-site.md](docs/adding-a-site.md) — Scaffold, configure, and deploy a new site
 - [docs/design-tokens.md](docs/design-tokens.md) — How presets work, creating custom palettes
+- [docs/framework-integrations.md](docs/framework-integrations.md) — Adding React/Vue/Svelte, Islands Architecture, View Transitions, Content Collections, and other Astro 6 capabilities
 - [docs/deployment.md](docs/deployment.md) — Cloudflare Pages, Vercel, Netlify, or self-hosted
 - [docs/ai-workflow.md](docs/ai-workflow.md) — Sample prompts and AI-driven development patterns

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ bun run dev --filter=yourdomain.com
 - **Design token system** — 3 presets (Corporate, SaaS, Warm) with a TypeScript interface. Create custom presets or modify colors and fonts per site without touching component code.
 - **Site scaffolder** — `./scripts/new-site.sh domain.com [preset]` creates a new site from the starter template with the correct config, styles, and build pipeline wired up.
 - **Infrastructure templates** — Optional Docker Compose + Traefik + Caddy setup for self-hosting on a VPS. Run `./scripts/setup-infra.sh` to generate configs for your domains.
+- **Framework-agnostic** — All components are native `.astro` files (zero JS by default). Need interactivity? Add React, Vue, Svelte, Solid, or Preact to any site — Astro's [Islands Architecture](https://docs.astro.build/en/concepts/islands/) hydrates only the interactive parts.
+- **Self-hosted fonts** — Astro 6 Fonts API downloads Google Fonts at build time and serves them from your domain. No runtime requests to third-party servers, better privacy, optimized fallbacks.
 - **AI-first workflow** — Designed to be developed with Claude Code, Gemini CLI, or any AI coding assistant. Sample prompts and patterns in the [AI Workflow Guide](docs/ai-workflow.md).
 
 ## Documentation
@@ -84,12 +86,13 @@ bun run dev --filter=yourdomain.com
 - [Adding a Site](docs/adding-a-site.md) — Create and configure additional sites
 - [Components Reference](docs/components.md) — Props, usage examples, CSS variables for every component
 - [Design Tokens](docs/design-tokens.md) — Branding system, presets, custom palettes
+- [Framework Integrations](docs/framework-integrations.md) — Add React/Vue/Svelte, Islands Architecture, View Transitions, Content Collections, and more
 - [Deployment](docs/deployment.md) — Cloudflare Pages, Vercel, Netlify, or self-hosted
 - [AI Workflow](docs/ai-workflow.md) — Sample prompts, tool setup, AI-driven development patterns
 
 ## Stack
 
-Astro 6 · Bun · Turborepo 2 · Tailwind CSS 4 · TypeScript · Static-first (zero JS by default)
+Astro 6 · Bun · Turborepo 2 · Tailwind CSS 4 · TypeScript · Static-first (zero JS by default) · Works with React, Vue, Svelte, Solid, Preact
 
 ## License
 

--- a/docs/framework-integrations.md
+++ b/docs/framework-integrations.md
@@ -1,0 +1,406 @@
+# Framework Integrations & Astro Capabilities
+
+Astro Fleet's 22 shared components are built as native `.astro` files — pure HTML templates with scoped CSS and zero framework dependencies. This is a deliberate choice: it means you can use **any** UI framework alongside them, or none at all.
+
+This guide covers how to add interactive framework components to your Fleet sites, and how to take advantage of Astro's broader feature set.
+
+---
+
+## Framework-agnostic by design
+
+Every component in `packages/shared-ui/` is a `.astro` file. At build time, Astro renders it to static HTML. No React runtime, no Vue reactivity system, no Svelte compiler output is shipped to the browser.
+
+**Why this matters:**
+
+- **No lock-in.** You're not forced into React because the starter uses React. You pick the framework that fits your team.
+- **Zero JS by default.** A page built entirely from Astro Fleet components ships zero client-side JavaScript. Your Lighthouse performance score starts at 100, not 60.
+- **Mix and match.** You can drop a React chart into a page that uses Astro Fleet's header, footer, and layout — they coexist without conflict.
+
+---
+
+## Adding a UI framework
+
+Astro supports **React, Vue, Svelte, Solid, Preact, Alpine.js, and Lit** as first-class integrations. Install one (or several) when you need client-side interactivity that pure HTML can't handle.
+
+### When to add a framework
+
+You need a framework when the component requires **client-side state, event handling, or reactivity** — things that can't be done with static HTML and CSS alone:
+
+- Interactive dashboards or data visualisations
+- Real-time search/filter with instant feedback
+- Complex form wizards with multi-step state
+- Animated UI that responds to user input (not just CSS hover/scroll)
+- Components you've already built in React/Vue/Svelte and want to reuse
+
+You **don't** need a framework for:
+
+- Navigation, headers, footers (Astro Fleet handles these)
+- Static content sections (hero, features, pricing, FAQ, testimonials)
+- Forms that submit to a backend (standard HTML `<form>` works)
+- Accordions and tabs (CSS-only solutions work — see FAQ and Tabs components)
+- Carousels (HeroSlider and TestimonialSlider use minimal vanilla JS)
+
+### Install a framework integration
+
+```bash
+# React
+bunx astro add react
+
+# Vue
+bunx astro add vue
+
+# Svelte
+bunx astro add svelte
+
+# Solid
+bunx astro add solid-js
+
+# Preact (lighter alternative to React)
+bunx astro add preact
+```
+
+This adds the integration to your site's `astro.config.mjs` automatically:
+
+```js
+import { defineConfig, fontProviders } from 'astro/config';
+import tailwindcss from '@tailwindcss/vite';
+import sitemap from '@astrojs/sitemap';
+import react from '@astrojs/react';  // ← added
+
+export default defineConfig({
+  site: 'https://www.yourdomain.com',
+  integrations: [sitemap(), react()],  // ← added
+  vite: { plugins: [tailwindcss()] },
+  output: 'static',
+  fonts: [ /* ... */ ],
+});
+```
+
+### Using framework components alongside Astro Fleet
+
+Once installed, create `.jsx`, `.tsx`, `.vue`, or `.svelte` files anywhere in your site's `src/` directory and import them into your Astro pages:
+
+```astro
+---
+// src/pages/dashboard.astro
+import BaseLayout from '@astro-fleet/shared-ui/src/layouts/BaseLayout.astro';
+import StatsBar from '@astro-fleet/shared-ui/src/components/StatsBar.astro';
+import FAQ from '@astro-fleet/shared-ui/src/components/FAQ.astro';
+import { SITE_NAME, navigation, footerColumns } from '../lib/site-config';
+import { CORPORATE } from '@astro-fleet/config/tokens';
+
+// Your React component
+import AnalyticsDashboard from '../components/AnalyticsDashboard';
+---
+
+<BaseLayout
+  title="Dashboard"
+  siteName={SITE_NAME}
+  navigation={navigation}
+  footerColumns={footerColumns}
+  designTokens={CORPORATE}
+>
+  <StatsBar items={stats} />
+
+  <!-- React component with client-side interactivity -->
+  <AnalyticsDashboard client:load />
+
+  <FAQ items={faqs} />
+</BaseLayout>
+```
+
+### Client directives — controlling when JS loads
+
+The `client:*` directive tells Astro when to hydrate your framework component. This is Astro's **Islands Architecture** — only the interactive parts of a page ship JavaScript:
+
+| Directive | When it hydrates | Use when |
+|-----------|-----------------|----------|
+| `client:load` | Immediately on page load | Critical interactive content (search bars, auth UI) |
+| `client:idle` | After the page is idle | Non-critical widgets (chat, analytics dashboards) |
+| `client:visible` | When scrolled into view | Below-the-fold content (charts, maps, comments) |
+| `client:media="(max-width: 768px)"` | When media query matches | Mobile-only interactions |
+| `client:only="react"` | Client-side only, no SSR | Components that can't be server-rendered |
+
+**Best practice:** Use `client:visible` or `client:idle` by default. Only use `client:load` for above-the-fold interactive content. This keeps your page fast while still enabling rich interactivity where needed.
+
+```astro
+<!-- This chart only loads JS when the user scrolls to it -->
+<RevenueChart client:visible data={chartData} />
+
+<!-- This search bar loads immediately because it's above the fold -->
+<SearchBar client:load placeholder="Search products..." />
+
+<!-- This chat widget loads after the page is idle -->
+<LiveChat client:idle />
+```
+
+### Using multiple frameworks on one site
+
+Astro supports using multiple frameworks simultaneously. Each component is its own island:
+
+```bash
+bunx astro add react
+bunx astro add svelte
+```
+
+```astro
+---
+import ReactChart from '../components/ReactChart';
+import SvelteForm from '../components/SvelteForm.svelte';
+---
+
+<!-- React and Svelte components on the same page -->
+<ReactChart client:visible data={chartData} />
+<SvelteForm client:load />
+```
+
+This is useful when migrating from one framework to another, or when different team members prefer different tools. Each component bundles only its own framework runtime.
+
+---
+
+## Sharing components across sites
+
+If you build a React/Vue/Svelte component that multiple sites need, you have two options:
+
+### Option 1: Add to shared-ui (recommended for Astro components)
+
+If the component is an `.astro` file (or can be), add it to `packages/shared-ui/src/components/`. This is the simplest path — it works exactly like the existing 22 components.
+
+### Option 2: Create a new shared package (for framework components)
+
+If the component is a `.tsx` or `.svelte` file that needs its framework runtime:
+
+```bash
+mkdir -p packages/shared-interactive/src/components
+```
+
+Create a `package.json`:
+
+```json
+{
+  "name": "@astro-fleet/shared-interactive",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./*": "./src/*"
+  }
+}
+```
+
+Add it as a dependency to sites that need it:
+
+```json
+{
+  "dependencies": {
+    "@astro-fleet/shared-interactive": "workspace:*"
+  }
+}
+```
+
+Then import from any site:
+
+```astro
+import Chart from '@astro-fleet/shared-interactive/components/Chart';
+```
+
+---
+
+## Astro capabilities you can adopt
+
+Beyond framework integrations, Astro 6 has several features that work well with Astro Fleet. Here's what's available and when to use each.
+
+### View Transitions (page morphing)
+
+Astro's built-in view transitions create smooth, app-like page navigation without a client-side router. Pages morph between each other instead of doing a full reload.
+
+```astro
+---
+// In your BaseLayout or page head
+import { ClientRouter } from 'astro:transitions';
+---
+<head>
+  <ClientRouter />
+</head>
+```
+
+Elements with matching `transition:name` attributes animate between pages:
+
+```astro
+<!-- On the list page -->
+<h2 transition:name="post-title">Article Title</h2>
+
+<!-- On the detail page — same transition:name, Astro morphs between them -->
+<h1 transition:name="post-title">Article Title</h1>
+```
+
+**When to use:** Sites that feel like apps — SaaS dashboards, documentation sites, portfolios. Not necessary for simple marketing sites where standard navigation is fine.
+
+### Content Collections
+
+Astro's content collections let you organise Markdown/MDX content with TypeScript-enforced schemas. Ideal for blogs, documentation, case studies, or any content-heavy section.
+
+```typescript
+// src/content.config.ts
+import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
+
+const blog = defineCollection({
+  loader: glob({ pattern: '**/*.md', base: './src/content/blog' }),
+  schema: z.object({
+    title: z.string(),
+    date: z.date(),
+    author: z.string(),
+    tags: z.array(z.string()).optional(),
+  }),
+});
+
+export const collections = { blog };
+```
+
+```astro
+---
+// src/pages/blog/index.astro
+import { getCollection } from 'astro:content';
+const posts = await getCollection('blog');
+---
+{posts.map(post => <article><h2>{post.data.title}</h2></article>)}
+```
+
+**When to use:** Any site that has structured content authored in Markdown — blogs, docs, changelogs, team bios, case studies.
+
+### Image Optimization
+
+Astro's built-in `<Image />` component automatically optimises images — resizing, format conversion (WebP/AVIF), and preventing layout shift:
+
+```astro
+---
+import { Image } from 'astro:assets';
+import heroImage from '../assets/hero.jpg';
+---
+<Image src={heroImage} alt="Hero banner" width={1200} height={600} />
+```
+
+**Benefits over a plain `<img>`:**
+- Automatic format conversion (serves WebP/AVIF to supported browsers)
+- Prevents Cumulative Layout Shift (CLS) by setting width/height
+- Lazy loading by default
+- Responsive `srcset` generation
+
+**When to use:** Always, for any image that isn't an SVG or icon. Especially important for hero images, product photos, and team headshots.
+
+### Middleware
+
+Astro middleware runs before every request, useful for authentication, logging, redirects, or injecting data:
+
+```typescript
+// src/middleware.ts
+import { defineMiddleware } from 'astro:middleware';
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  const response = await next();
+  response.headers.set('X-Custom-Header', 'Astro Fleet');
+  return response;
+});
+```
+
+**When to use:** Server-rendered sites (`output: 'server'` or `output: 'hybrid'`) that need request-level logic. Not applicable to fully static sites (our default).
+
+### Actions (type-safe backend functions)
+
+Astro Actions let you define type-safe server functions that your pages can call:
+
+```typescript
+// src/actions/index.ts
+import { defineAction, z } from 'astro:actions';
+
+export const server = {
+  submitContact: defineAction({
+    input: z.object({
+      name: z.string(),
+      email: z.string().email(),
+      message: z.string(),
+    }),
+    handler: async (input) => {
+      // Send email, save to database, etc.
+      return { success: true };
+    },
+  }),
+};
+```
+
+**When to use:** When you need server-side logic (form handling, API calls, database writes) without building a separate API. Requires `output: 'server'` or `output: 'hybrid'`.
+
+### Prefetching
+
+Astro can prefetch links when they come into view or on hover, making subsequent page loads feel instant:
+
+```js
+// astro.config.mjs
+export default defineConfig({
+  prefetch: {
+    prefetchAll: true,         // prefetch all links
+    defaultStrategy: 'hover',  // or 'viewport', 'load'
+  },
+});
+```
+
+**When to use:** Marketing sites and documentation where users browse multiple pages. The default `hover` strategy is a good balance — it prefetches when the user moves their cursor toward a link, adding ~100ms head start.
+
+### Content Security Policy (CSP)
+
+New in Astro 6 — automatic CSP header generation to protect against XSS attacks:
+
+```js
+// astro.config.mjs
+export default defineConfig({
+  security: {
+    csp: true,  // automatic hash-based CSP for scripts and styles
+  },
+});
+```
+
+**When to use:** Any production site, especially those handling user data. CSP is a defence-in-depth measure that prevents inline script injection even if an XSS vulnerability exists.
+
+### Environment Variables
+
+Astro 6 inlines `import.meta.env` values at build time. Remember that values are always strings:
+
+```js
+// Correct
+const isEnabled = import.meta.env.FEATURE_FLAG === 'true';
+
+// Incorrect (won't work as expected in Astro 6)
+const isEnabled = import.meta.env.FEATURE_FLAG; // this is a string, not boolean
+```
+
+Public env vars (prefixed with `PUBLIC_`) are available in client-side code. Private vars are only available server-side.
+
+---
+
+## Architecture decision: when to use what
+
+| Need | Solution | JS shipped? |
+|------|----------|------------|
+| Static content (text, images, cards) | `.astro` components (Astro Fleet) | None |
+| Form submission | HTML `<form>` + backend endpoint | None |
+| Accordion, tabs | CSS-only (FAQ, details/summary) | None |
+| Carousel | Vanilla JS (HeroSlider, TestimonialSlider) | ~1KB |
+| Interactive chart/dashboard | React/Vue/Svelte + `client:visible` | Framework runtime |
+| Real-time search/filter | React/Vue/Svelte + `client:load` | Framework runtime |
+| Complex multi-step form | React/Vue/Svelte + `client:load` | Framework runtime |
+| Full SPA-like experience | Consider Next.js/SvelteKit instead | Everything |
+
+**The rule of thumb:** Start with Astro Fleet's static components. Add a framework component only when you hit something that genuinely requires client-side state. Most marketing sites, corporate sites, and restaurants never need to.
+
+---
+
+## Recommended reading
+
+- [Astro Documentation](https://docs.astro.build/) — the official docs, comprehensive and well-maintained
+- [Astro Islands](https://docs.astro.build/en/concepts/islands/) — understanding the partial hydration architecture
+- [Framework Integrations](https://docs.astro.build/en/guides/framework-components/) — detailed setup for each framework
+- [Content Collections](https://docs.astro.build/en/guides/content-collections/) — organising Markdown/MDX with schemas
+- [View Transitions](https://docs.astro.build/en/guides/view-transitions/) — smooth page-to-page animations
+- [Astro Actions](https://docs.astro.build/en/guides/actions/) — type-safe server functions
+- [Image Optimization](https://docs.astro.build/en/guides/images/) — automatic image processing

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ Get Astro Fleet running locally in under five minutes.
 
 - **[Bun](https://bun.sh)** — install with `curl -fsSL https://bun.sh/install | bash`
 - **Git**
-- **Node.js 18+** (Bun bundles its own Node-compatible runtime, but some Astro tooling needs it)
+- **Node.js 22.12+** (required by Astro 6 — check with `node --version`)
 
 ## 1. Clone the repository
 


### PR DESCRIPTION
## Summary

Adds a comprehensive guide explaining that Astro Fleet is **framework-agnostic** and how to leverage Astro's full feature set.

## Why this matters

Someone evaluating Astro Fleet might see `.astro` files everywhere and assume they're locked out of React/Vue/Svelte. This doc makes it clear: all 22 components are pure Astro (zero JS) **by design**, and any UI framework can be added alongside them when interactivity is needed.

## What's in docs/framework-integrations.md

**Framework integration (~60% of the doc):**
- Why components are framework-agnostic and why that's the right choice
- When you need a framework vs. when you don't (decision guide)
- Step-by-step: installing React/Vue/Svelte/Solid/Preact
- Using framework components alongside Astro Fleet components (code examples)
- Client directives explained (`client:load`, `client:idle`, `client:visible`) with real use cases
- Using multiple frameworks on one site
- Sharing framework components across sites in the monorepo

**Astro 6 capabilities (~40% of the doc):**
- View Transitions (page morphing)
- Content Collections (Markdown/MDX with schemas)
- Image Optimization (automatic WebP/AVIF, CLS prevention)
- Middleware (request-level logic)
- Actions (type-safe backend functions)
- Prefetching (instant page navigation)
- CSP (Content Security Policy)
- Environment variables (Astro 6 inlining behavior)
- Architecture decision table: when to use static vs. framework components

## Also updated

- **README.md** — "Framework-agnostic" and "Self-hosted fonts" added to What's Included; Framework Integrations in docs list; framework names in Stack line
- **CLAUDE.md** — framework-integrations.md added to docs references
- **getting-started.md** — Node.js requirement fixed (18+ → 22.12+ for Astro 6)

## Test plan

- [x] `bun run build` passes
- [x] All docs render correctly in GitHub markdown
- [ ] CI passes