### PR TITLE
feat: SEO hardening — P0 meta fixes, auto JSON-LD, headers, RSS, recipes docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ For in-depth guidance beyond what's in this file, refer to:
 - [docs/getting-started.md](docs/getting-started.md) — Clone to first deploy in 15 minutes
 - [docs/adding-a-site.md](docs/adding-a-site.md) — Scaffold, configure, and deploy a new site
 - [docs/adding-a-cms.md](docs/adding-a-cms.md) — Keystatic pattern used in Meridian, access-control caveats, and alternatives
+- [docs/seo-recipes.md](docs/seo-recipes.md) — Optional SEO add-ons not baked into the starter (per-page OG images, git-based lastmod, llms.txt, markdown alternates, IndexNow, FuzzyRedirect, view transitions)
 - [docs/design-tokens.md](docs/design-tokens.md) — How presets work, creating custom palettes
 - [docs/framework-integrations.md](docs/framework-integrations.md) — Adding React/Vue/Svelte, Islands Architecture, View Transitions, Content Collections, and other Astro 6 capabilities
 - [docs/deployment.md](docs/deployment.md) — Cloudflare Pages, Vercel, Netlify, or self-hosted

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ bun install
 - [Getting Started](docs/getting-started.md) — Clone to first deploy in 15 minutes
 - [Adding a Site](docs/adding-a-site.md) — Create and configure additional sites
 - [Adding a CMS](docs/adding-a-cms.md) — Keystatic pattern used in Meridian, plus when to pick a different CMS
+- [SEO Recipes](docs/seo-recipes.md) — Optional SEO add-ons (per-page OG images, git-based lastmod, llms.txt, IndexNow, view transitions, and more)
 - [Components Reference](docs/components.md) — Props, usage examples, CSS variables for every component
 - [Design Tokens](docs/design-tokens.md) — Branding system, presets, custom palettes
 - [Framework Integrations](docs/framework-integrations.md) — Add React/Vue/Svelte, Islands Architecture, View Transitions, Content Collections, and more

--- a/bun.lock
+++ b/bun.lock
@@ -52,6 +52,7 @@
         "@astro-fleet/shared-ui": "workspace:*",
         "@astrojs/markdoc": "^1.0.3",
         "@astrojs/react": "^5.0.3",
+        "@astrojs/rss": "^4.0.18",
         "@keystatic/astro": "^5.0.6",
         "@keystatic/core": "^0.5.50",
         "astro": "^6.1.7",
@@ -129,6 +130,8 @@
     "@astrojs/prism": ["@astrojs/prism@4.0.1", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ=="],
 
     "@astrojs/react": ["@astrojs/react@5.0.3", "", { "dependencies": { "@astrojs/internal-helpers": "0.8.0", "@vitejs/plugin-react": "^5.2.0", "devalue": "^5.6.4", "ultrahtml": "^1.6.0", "vite": "^7.3.1" }, "peerDependencies": { "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0", "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0" } }, "sha512-z6JXjgADH4/7e0hqcRj+dO9UQlrKmsm2ZJoVT1GzOTYY0ThQ3Znpfr8tY8XKlEHWSTUlT9LP5u4v6QpEJwLz5A=="],
+
+    "@astrojs/rss": ["@astrojs/rss@4.0.18", "", { "dependencies": { "fast-xml-parser": "^5.5.7", "piccolore": "^0.1.3", "zod": "^4.3.6" } }, "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg=="],
 
     "@astrojs/sitemap": ["@astrojs/sitemap@3.7.2", "", { "dependencies": { "sitemap": "^9.0.0", "stream-replace-string": "^2.0.0", "zod": "^4.3.6" } }, "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA=="],
 
@@ -371,6 +374,8 @@
     "@keystatic/core": ["@keystatic/core@0.5.50", "", { "dependencies": { "@babel/runtime": "^7.18.3", "@braintree/sanitize-url": "^6.0.2", "@emotion/weak-memoize": "^0.3.0", "@floating-ui/react": "^0.24.0", "@internationalized/string": "^3.2.6", "@keystar/ui": "^0.7.21", "@markdoc/markdoc": "^0.4.0", "@react-aria/focus": "^3.20.2", "@react-aria/i18n": "^3.12.8", "@react-aria/interactions": "^3.25.0", "@react-aria/label": "^3.7.17", "@react-aria/overlays": "^3.27.0", "@react-aria/selection": "^3.24.0", "@react-aria/utils": "^3.28.2", "@react-aria/visually-hidden": "^3.8.22", "@react-stately/collections": "^3.12.3", "@react-stately/list": "^3.12.1", "@react-stately/overlays": "^3.6.15", "@react-stately/utils": "^3.10.6", "@react-types/shared": "^3.29.0", "@sindresorhus/slugify": "^1.1.2", "@toeverything/y-indexeddb": "^0.10.0-canary.9", "@ts-gql/tag": "^0.7.3", "@types/react": "^19.0.8", "@urql/core": "^5.0.4", "@urql/exchange-auth": "^2.2.0", "@urql/exchange-graphcache": "^7.1.2", "@urql/exchange-persisted": "^4.3.0", "cookie": "^1.0.0", "emery": "^1.4.1", "escape-string-regexp": "^4.0.0", "fast-deep-equal": "^3.1.3", "graphql": "^16.6.0", "idb-keyval": "^6.2.1", "ignore": "^5.2.4", "is-hotkey": "^0.2.0", "js-yaml": "^4.1.0", "lib0": "^0.2.88", "lru-cache": "^10.2.0", "match-sorter": "^6.3.1", "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-mdx": "^3.0.0", "mdast-util-to-markdown": "^2.1.0", "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-mdxjs": "^3.0.0", "minimatch": "^9.0.3", "partysocket": "^0.0.22", "prosemirror-commands": "^1.5.1", "prosemirror-history": "^1.3.0", "prosemirror-keymap": "^1.2.1", "prosemirror-model": "^1.19.0", "prosemirror-state": "^1.4.2", "prosemirror-tables": "^1.3.4", "prosemirror-transform": "^1.7.1", "prosemirror-view": "^1.30.2", "scroll-into-view-if-needed": "^3.0.3", "slate": "^0.91.4", "slate-history": "^0.86.0", "slate-react": "^0.91.9", "superstruct": "^1.0.4", "unist-util-visit": "^5.0.0", "urql": "^4.1.0", "y-prosemirror": "^1.2.2", "y-protocols": "^1.0.6", "yjs": "^13.6.11" }, "peerDependencies": { "react": "^18.2.0 || ^19.0.0", "react-dom": "^18.2.0 || ^19.0.0" } }, "sha512-ilgG9hw1iWZsT8iCV+1WFX1VNo6eK+iHIs61x4vRtce6SstKad6ib7BLhXEP41Q8ja6JIKWXvv6qBPVumyy88Q=="],
 
     "@markdoc/markdoc": ["@markdoc/markdoc@0.5.7", "", { "optionalDependencies": { "@types/linkify-it": "^3.0.1", "@types/markdown-it": "12.2.3" }, "peerDependencies": { "@types/react": "*", "react": "*" }, "optionalPeers": ["@types/react", "react"] }, "sha512-NxreNThm7foFgMMQD6zgk7rKkcFMmdC8J5r+Zn4FKoN75F5YjvwdihwF11VhrBfL3CXnD4+YG1VYwvBL+igzvw=="],
+
+    "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
@@ -960,6 +965,10 @@
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.1.6", "", { "dependencies": { "fast-string-width": "^1.1.0" } }, "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w=="],
 
+    "fast-xml-builder": ["fast-xml-builder@1.1.5", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.7.0", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.5", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-MTcrUoRQ1GSQ9iG3QJzBGquYYYeA7piZaJoIWbPFGbRn6Jj6z7xgoAyi4DrZX4y2ZIQQBF59gc/zmvvejjgoFQ=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "find-root": ["find-root@1.1.0", "", {}, "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="],
@@ -1310,6 +1319,8 @@
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
+    "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
@@ -1459,6 +1470,8 @@
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strnum": ["strnum@2.2.3", "", {}, "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg=="],
 
     "stylis": ["stylis@4.2.0", "", {}, "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="],
 

--- a/docs/seo-recipes.md
+++ b/docs/seo-recipes.md
@@ -1,0 +1,254 @@
+# SEO Recipes
+
+Optional SEO enhancements that aren't baked into the starter because they're either opinionated, add dependencies, or only pay off for certain site shapes. Pick what you need.
+
+For the always-on SEO that's already wired in (canonical URLs, robots directives, OG/Twitter cards, JSON-LD `WebSite` + `Organization` graph, sitemaps, RSS on Meridian, immutable asset caching), see `packages/shared-ui/src/components/SEOHead.astro` and `docs/adding-a-cms.md`.
+
+## 1. Per-page Open Graph images
+
+**When to add:** content sites, blogs, docs — anywhere each page deserves its own social card.
+
+**What you get:** dynamic 1200×630 JPEG rendered at build time from the page's title and metadata. Share to LinkedIn/Twitter/Slack and the card unfurls with a per-page image instead of a single default.
+
+**Why JPEG:** LinkedIn, Slack, and some older scrapers don't reliably render WebP/AVIF in unfurls.
+
+Install:
+
+```bash
+bun add satori satori-html sharp
+```
+
+Create `src/pages/og/[...slug].jpg.ts`:
+
+```ts
+import type { APIRoute } from 'astro';
+import satori from 'satori';
+import { html } from 'satori-html';
+import sharp from 'sharp';
+import { readFile } from 'node:fs/promises';
+
+const fontBuf = await readFile('./public/fonts/inter-bold.ttf');
+
+export const GET: APIRoute = async ({ params }) => {
+  const title = decodeURIComponent(params.slug ?? 'Untitled');
+
+  const markup = html(`
+    <div style="display:flex;flex-direction:column;justify-content:space-between;
+                width:1200px;height:630px;padding:80px;background:#0a0f14;color:#fff;
+                font-family:Inter">
+      <div style="font-size:28px;opacity:.6">yoursite.com</div>
+      <div style="font-size:72px;font-weight:700;line-height:1.1">${title}</div>
+    </div>
+  `);
+
+  const svg = await satori(markup, {
+    width: 1200,
+    height: 630,
+    fonts: [{ name: 'Inter', data: fontBuf, weight: 700, style: 'normal' }],
+  });
+
+  const jpg = await sharp(Buffer.from(svg)).jpeg({ quality: 90 }).toBuffer();
+
+  return new Response(jpg, {
+    headers: { 'Content-Type': 'image/jpeg', 'Cache-Control': 'public, max-age=31536000, immutable' },
+  });
+};
+```
+
+Wire it from your page:
+
+```astro
+<BaseLayout
+  title={entry.data.title}
+  ogImage={`/og/${entry.id}.jpg`}
+  ogImageAlt={entry.data.title}
+/>
+```
+
+## 2. Git-based sitemap lastmod
+
+**Problem:** file `mtime` resets on CI runners, so `@astrojs/sitemap`'s default `lastmod` always reads as "now." Search engines learn to ignore it.
+
+**Fix:** derive `lastmod` from git's last-commit date for each source file. Use `execFileSync` with an argv array rather than `execSync` with a template string — the path comes from the sitemap serializer and shelling it out risks command injection on filenames with unusual characters.
+
+```ts
+// astro.config.mjs
+import sitemap from '@astrojs/sitemap';
+import { execFileSync } from 'node:child_process';
+
+function gitLastMod(relPath) {
+  try {
+    const iso = execFileSync('git', ['log', '-1', '--format=%cI', '--', relPath], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return iso || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export default defineConfig({
+  // ...
+  integrations: [
+    sitemap({
+      serialize(item) {
+        if (item.url.includes('/insights/')) {
+          const slug = item.url.split('/insights/')[1].replace(/\/$/, '');
+          const lm = gitLastMod(`src/content/insights/${slug}/index.mdoc`);
+          if (lm) item.lastmod = lm;
+        }
+        return item;
+      },
+    }),
+  ],
+});
+```
+
+## 3. `llms.txt` — machine-readable site summary
+
+**When to add:** any content site that wants AI assistants (ChatGPT, Claude, Perplexity) to understand its structure.
+
+Serve `/llms.txt` as a static route that lists the high-value URLs with short descriptions. Minimum viable version:
+
+```ts
+// src/pages/llms.txt.ts
+import { getCollection } from 'astro:content';
+
+export async function GET() {
+  const insights = await getCollection('insights');
+  const lines = [
+    '# Meridian Advisory',
+    '',
+    '> Independent strategy and transformation advisory for regulated institutions.',
+    '',
+    '## Insights',
+    '',
+    ...insights.map((e) => `- [${e.data.title}](/insights/${e.id}/): ${e.data.summary}`),
+  ].join('\n');
+  return new Response(lines, { headers: { 'Content-Type': 'text/plain' } });
+}
+```
+
+## 4. Markdown alternates
+
+**Use case:** AI crawlers (Perplexity in particular) prefer raw markdown over HTML. Expose a `.md` version of each article.
+
+```ts
+// src/pages/insights/[slug].md.ts
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+export async function getStaticPaths() {
+  const entries = await getCollection('insights');
+  return entries.map((entry) => ({ params: { slug: entry.id }, props: { entry } }));
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props;
+  const body = `# ${entry.data.title}\n\n${entry.data.summary}\n\n${entry.body}`;
+  return new Response(body, { headers: { 'Content-Type': 'text/markdown; charset=utf-8' } });
+};
+```
+
+Advertise on the HTML page:
+
+```astro
+<link rel="alternate" type="text/markdown" href={`/insights/${entry.id}.md`} />
+```
+
+## 5. IndexNow — ping Bing and Yandex on deploy
+
+**When to add:** high-frequency publishing; reduces indexing lag from days to minutes.
+
+1. Generate a key (`openssl rand -hex 16`).
+2. Serve it as `public/<key>.txt` containing the same key (for host verification).
+3. Add a post-deploy step that POSTs your updated URLs to `https://api.indexnow.org/indexnow`:
+
+```ts
+// scripts/indexnow.ts
+const KEY = process.env.INDEXNOW_KEY!;
+const HOST = 'www.meridian-advisory.com';
+
+const urls = [
+  `https://${HOST}/`,
+  `https://${HOST}/insights/`,
+  // ...or read from the built sitemap
+];
+
+await fetch('https://api.indexnow.org/indexnow', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ host: HOST, key: KEY, keyLocation: `https://${HOST}/${KEY}.txt`, urlList: urls }),
+});
+```
+
+Wire into your deploy workflow (after `wrangler pages deploy`).
+
+## 6. FuzzyRedirect on 404
+
+**When to add:** after a URL migration, or for content-heavy sites where typos are common.
+
+Fetch the sitemap client-side on the 404 page, compute Levenshtein distance between the requested URL and each known URL, and either auto-redirect on 85%+ similarity or render suggestions.
+
+The `@jdevalk/astro-seo-graph` package ships a `FuzzyRedirect.astro` component — easiest path if you're already using it. Otherwise, ~40 lines of plain JS on the 404 page.
+
+## 7. View transitions
+
+**When to add:** want smooth page transitions and a bit of a perf bump from pre-cached navigation.
+
+```astro
+---
+// BaseLayout.astro or the site's root layout
+import { ClientRouter } from 'astro:transitions';
+---
+<head>
+  <ClientRouter defaultStrategy="viewport" />
+  <!-- ... -->
+</head>
+```
+
+Not baked into the starter because it's a meaningful UX opinion — some sites want full page reloads for analytics / form reset reasons.
+
+## 8. Schema endpoints + schemamap
+
+**When to add:** you're emitting a lot of rich JSON-LD and want agents to find it in one place.
+
+Expose a combined graph per collection at `/schema/insights.json`, then list all endpoints at `/schemamap.xml`, then reference the schemamap from `robots.txt`:
+
+```
+# public/robots.txt
+User-agent: *
+Allow: /
+
+Sitemap: https://www.meridian-advisory.com/sitemap-index.xml
+Schemamap: https://www.meridian-advisory.com/schemamap.xml
+```
+
+## 9. NLWeb discovery
+
+Emerging standard for conversational AI agents. One line in head:
+
+```astro
+<link rel="nlweb" href="/.well-known/nlweb.json" />
+```
+
+Serve a small JSON descriptor at that path. Low effort, future-proof.
+
+## 10. Build-time validation
+
+Catch SEO regressions before they ship. Add a post-build script that walks `dist/**/*.html` and asserts:
+
+- Every page has exactly one `<h1>`
+- No two pages share a `<title>`
+- Every `<img>` has an `alt`
+- Every internal link resolves
+- Title length 30–65, description 70–200
+
+Keep it out of `astro check` (which is type-only) and wire it into CI as a separate step. The [`lychee`](https://github.com/lycheeverse/lychee-action) GitHub Action handles internal + external link validation in ~1 line of YAML.
+
+---
+
+## When you hit the ceiling
+
+If you end up implementing more than three of these, consider [`@jdevalk/astro-seo-graph`](https://github.com/jdevalk/seo-graph). It bundles the `Seo` component, schema endpoints, schemamap, IndexNow, llms.txt, FuzzyRedirect, build-time validation, and markdown alternates as one typed package. Tradeoff: you adopt his opinionated API surface in return for not maintaining the plumbing yourself.

--- a/packages/shared-ui/src/components/SEOHead.astro
+++ b/packages/shared-ui/src/components/SEOHead.astro
@@ -32,6 +32,12 @@ export interface Props {
   rssUrl?: string;
   /** Optional RSS feed title. Defaults to '<siteName> — RSS'. */
   rssTitle?: string;
+  /** Root-relative or absolute URL to site logo. Emitted as Organization.logo in JSON-LD. */
+  logoUrl?: string;
+  /** Social profile URLs for Organization.sameAs. Linkedin, Twitter, etc. */
+  sameAs?: string[];
+  /** Skip auto-generated WebSite + Organization JSON-LD. Use when pages manage their own full graph. */
+  skipAutoJsonLd?: boolean;
 }
 
 const {
@@ -51,6 +57,9 @@ const {
   faviconType = 'image/svg+xml',
   rssUrl,
   rssTitle,
+  logoUrl,
+  sameAs,
+  skipAutoJsonLd = false,
 } = Astro.props;
 
 const pageTitle = siteName && !title.includes(siteName) ? `${title} | ${siteName}` : title;
@@ -65,6 +74,56 @@ const normalizedTwitter = twitterHandle
 
 const resolvedOgImageAlt = ogImageAlt || title;
 const resolvedRssTitle = rssTitle || (siteName ? `${siteName} — RSS` : 'RSS Feed');
+
+// Build a linked JSON-LD @graph from props. Pages can pass additional nodes
+// via structuredData — they're appended to the same graph so @id refs resolve.
+const origin = Astro.site?.origin || Astro.url.origin;
+const siteRootUrl = (Astro.site?.href || `${origin}/`).replace(/\/+$/, '/') ;
+const resolvedLogoUrl = logoUrl
+  ? (logoUrl.startsWith('http') ? logoUrl : new URL(logoUrl, origin).href)
+  : undefined;
+
+const graph: Record<string, unknown>[] = [];
+
+if (!skipAutoJsonLd && siteName) {
+  graph.push({
+    '@type': 'WebSite',
+    '@id': `${origin}/#website`,
+    url: siteRootUrl,
+    name: siteName,
+    inLanguage: locale.replace('_', '-'),
+    publisher: { '@id': `${origin}/#organization` },
+  });
+
+  const organization: Record<string, unknown> = {
+    '@type': 'Organization',
+    '@id': `${origin}/#organization`,
+    name: siteName,
+    url: siteRootUrl,
+  };
+  if (resolvedLogoUrl) {
+    organization.logo = {
+      '@type': 'ImageObject',
+      '@id': `${origin}/#logo`,
+      url: resolvedLogoUrl,
+      contentUrl: resolvedLogoUrl,
+    };
+    organization.image = { '@id': `${origin}/#logo` };
+  }
+  if (sameAs && sameAs.length > 0) {
+    organization.sameAs = sameAs;
+  }
+  graph.push(organization);
+}
+
+// User-supplied nodes — strip @context so they merge cleanly into our graph.
+const userNodes = structuredData
+  ? (Array.isArray(structuredData) ? structuredData : [structuredData])
+  : [];
+for (const node of userNodes) {
+  const { ['@context']: _ctx, ...rest } = node as Record<string, unknown>;
+  graph.push(rest);
+}
 ---
 
 <meta charset="utf-8" />
@@ -114,12 +173,9 @@ const resolvedRssTitle = rssTitle || (siteName ? `${siteName} — RSS` : 'RSS Fe
 )}
 
 <!-- Structured Data (JSON-LD) -->
-{structuredData && (
-  Array.isArray(structuredData) ? (
-    structuredData.map((node) => (
-      <script type="application/ld+json" set:html={JSON.stringify(node)} />
-    ))
-  ) : (
-    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
-  )
+{graph.length > 0 && (
+  <script
+    type="application/ld+json"
+    set:html={JSON.stringify({ '@context': 'https://schema.org', '@graph': graph })}
+  />
 )}

--- a/packages/shared-ui/src/components/SEOHead.astro
+++ b/packages/shared-ui/src/components/SEOHead.astro
@@ -1,35 +1,70 @@
 ---
 export interface Props {
+  /** Page title (site name appended automatically if provided via siteName). */
   title: string;
+  /** Meta description — 70–200 chars for SERP safety. */
   description: string;
+  /** Additional JSON-LD to emit alongside auto-generated graph. Object or array accepted. */
+  structuredData?: Record<string, unknown> | Record<string, unknown>[];
+  /** @deprecated Accepted for backward compat but not emitted — meta keywords is ignored by all major search engines. */
   keywords?: string[];
-  structuredData?: Record<string, unknown>;
+  /** Override canonical — otherwise derived from Astro.site + pathname. */
   canonicalUrl?: string;
+  /** Absolute or root-relative OG image URL. If omitted, og:image is not emitted. */
   ogImage?: string;
+  /** Alt text for og:image. Falls back to the page title. */
+  ogImageAlt?: string;
+  /** Site name used in title suffix and og:site_name. */
   siteName?: string;
+  /** og:type — default 'website'. Use 'article' for blog posts. */
   ogType?: string;
+  /** Locale — default 'en_US'. */
   locale?: string;
+  /** Twitter handle, with or without @. */
   twitterHandle?: string;
+  /** If true: emits noindex, nofollow and suppresses canonical. */
   noindex?: boolean;
+  /** Favicon path — default '/favicon.svg'. */
+  faviconHref?: string;
+  /** Favicon MIME type — default 'image/svg+xml'. */
+  faviconType?: string;
+  /** Optional RSS feed URL to advertise via <link rel="alternate">. */
+  rssUrl?: string;
+  /** Optional RSS feed title. Defaults to '<siteName> — RSS'. */
+  rssTitle?: string;
 }
 
 const {
   title,
   description,
-  keywords = [],
   structuredData,
+  keywords: _keywords,
   canonicalUrl,
   ogImage,
+  ogImageAlt,
   siteName = '',
   ogType = 'website',
   locale = 'en_US',
   twitterHandle,
   noindex = false,
+  faviconHref = '/favicon.svg',
+  faviconType = 'image/svg+xml',
+  rssUrl,
+  rssTitle,
 } = Astro.props;
 
 const pageTitle = siteName && !title.includes(siteName) ? `${title} | ${siteName}` : title;
-const defaultOgImage = ogImage || `${Astro.url.origin}/images/og-default.png`;
-const resolvedCanonical = canonicalUrl || new URL(Astro.url.pathname, Astro.site || Astro.url.origin).href;
+const resolvedCanonical =
+  canonicalUrl || new URL(Astro.url.pathname, Astro.site || Astro.url.origin).href;
+
+const normalizedTwitter = twitterHandle
+  ? twitterHandle.startsWith('@')
+    ? twitterHandle
+    : `@${twitterHandle}`
+  : undefined;
+
+const resolvedOgImageAlt = ogImageAlt || title;
+const resolvedRssTitle = rssTitle || (siteName ? `${siteName} — RSS` : 'RSS Feed');
 ---
 
 <meta charset="utf-8" />
@@ -38,32 +73,53 @@ const resolvedCanonical = canonicalUrl || new URL(Astro.url.pathname, Astro.site
 <title>{pageTitle}</title>
 <meta name="description" content={description} />
 
-{keywords.length > 0 && (
-  <meta name="keywords" content={keywords.join(',')} />
+<link rel="icon" type={faviconType} href={faviconHref} />
+
+{noindex ? (
+  <meta name="robots" content="noindex, nofollow" />
+) : (
+  <meta
+    name="robots"
+    content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1"
+  />
 )}
 
-{noindex && <meta name="robots" content="noindex, nofollow" />}
+{/* Canonical is suppressed on noindex pages — two contradictory signals hurt rankings. */}
+{!noindex && <link rel="canonical" href={resolvedCanonical} />}
 
 <!-- Open Graph -->
 <meta property="og:title" content={pageTitle} />
 <meta property="og:description" content={description} />
 <meta property="og:type" content={ogType} />
 <meta property="og:locale" content={locale} />
-<meta property="og:image" content={defaultOgImage} />
 <meta property="og:url" content={resolvedCanonical} />
 {siteName && <meta property="og:site_name" content={siteName} />}
+{ogImage && (
+  <>
+    <meta property="og:image" content={ogImage} />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content={resolvedOgImageAlt} />
+  </>
+)}
 
 <!-- Twitter Card -->
 <meta name="twitter:card" content={ogImage ? 'summary_large_image' : 'summary'} />
-<meta name="twitter:title" content={pageTitle} />
-<meta name="twitter:description" content={description} />
-<meta name="twitter:image" content={defaultOgImage} />
-{twitterHandle && <meta name="twitter:site" content={twitterHandle} />}
+{normalizedTwitter && <meta name="twitter:site" content={normalizedTwitter} />}
+{/* Twitter falls back to og:title/description/image; no need to duplicate unless they differ. */}
 
-<!-- Canonical URL -->
-<link rel="canonical" href={resolvedCanonical} />
+<!-- RSS -->
+{rssUrl && (
+  <link rel="alternate" type="application/rss+xml" title={resolvedRssTitle} href={rssUrl} />
+)}
 
 <!-- Structured Data (JSON-LD) -->
 {structuredData && (
-  <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
+  Array.isArray(structuredData) ? (
+    structuredData.map((node) => (
+      <script type="application/ld+json" set:html={JSON.stringify(node)} />
+    ))
+  ) : (
+    <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
+  )
 )}

--- a/packages/shared-ui/src/layouts/BaseLayout.astro
+++ b/packages/shared-ui/src/layouts/BaseLayout.astro
@@ -20,6 +20,18 @@ export interface Props {
   canonicalUrl?: string;
   /** Open Graph image URL */
   ogImage?: string;
+  /** Alt text for og:image (defaults to page title) */
+  ogImageAlt?: string;
+  /** og:type — 'website' (default), 'article', etc. */
+  ogType?: string;
+  /** Twitter handle, with or without @ */
+  twitterHandle?: string;
+  /** Emits noindex and suppresses canonical */
+  noindex?: boolean;
+  /** RSS feed URL to advertise via <link rel="alternate"> */
+  rssUrl?: string;
+  /** Skip auto-generated WebSite/Organization JSON-LD (for pages that emit a full custom graph) */
+  skipAutoJsonLd?: boolean;
   /** Navigation menu items */
   navigation: MenuItem[];
   /** Footer link columns */
@@ -57,6 +69,12 @@ const {
   structuredData,
   canonicalUrl,
   ogImage,
+  ogImageAlt,
+  ogType,
+  twitterHandle,
+  noindex,
+  rssUrl,
+  skipAutoJsonLd,
   navigation,
   footerColumns,
   contactInfo,
@@ -71,6 +89,8 @@ const {
   bodyClass = '',
 } = Astro.props;
 
+const sameAs = socialLinks?.map((s) => s.url).filter(Boolean);
+
 const cssVars = designTokens ? tokensToCSSVars(designTokens) : '';
 ---
 
@@ -84,7 +104,15 @@ const cssVars = designTokens ? tokensToCSSVars(designTokens) : '';
       structuredData={structuredData}
       canonicalUrl={canonicalUrl}
       ogImage={ogImage}
+      ogImageAlt={ogImageAlt}
+      ogType={ogType}
+      twitterHandle={twitterHandle}
+      noindex={noindex}
+      rssUrl={rssUrl}
       siteName={siteName}
+      logoUrl={logoSrc}
+      sameAs={sameAs}
+      skipAutoJsonLd={skipAutoJsonLd}
     />
     {/* CSS vars from tokensToCSSVars() — safe because source is static TypeScript config, not user input */}
     {cssVars && (

--- a/sites/flux-analytics.com/public/_headers
+++ b/sites/flux-analytics.com/public/_headers
@@ -1,0 +1,12 @@
+# Cloudflare Pages / Netlify-compatible headers
+# See https://developers.cloudflare.com/pages/configuration/headers/
+
+# Astro emits hashed filenames under /_astro/ (including fonts under /_astro/fonts/).
+# Hashed URLs are safe to cache forever — content changes ⇒ filename changes.
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Keep UTM + ad-click tracking params out of the CDN cache key so a single cached
+# response is served regardless of marketing attribution.
+/*
+  No-Vary-Search: params=("utm_source" "utm_medium" "utm_campaign" "utm_term" "utm_content" "gclid" "fbclid" "ref")

--- a/sites/meridian-advisory.com/package.json
+++ b/sites/meridian-advisory.com/package.json
@@ -14,6 +14,7 @@
     "@astro-fleet/shared-ui": "workspace:*",
     "@astrojs/markdoc": "^1.0.3",
     "@astrojs/react": "^5.0.3",
+    "@astrojs/rss": "^4.0.18",
     "@keystatic/astro": "^5.0.6",
     "@keystatic/core": "^0.5.50",
     "astro": "^6.1.7",

--- a/sites/meridian-advisory.com/public/_headers
+++ b/sites/meridian-advisory.com/public/_headers
@@ -1,0 +1,12 @@
+# Cloudflare Pages / Netlify-compatible headers
+# See https://developers.cloudflare.com/pages/configuration/headers/
+
+# Astro emits hashed filenames under /_astro/ (including fonts under /_astro/fonts/).
+# Hashed URLs are safe to cache forever — content changes ⇒ filename changes.
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Keep UTM + ad-click tracking params out of the CDN cache key so a single cached
+# response is served regardless of marketing attribution.
+/*
+  No-Vary-Search: params=("utm_source" "utm_medium" "utm_campaign" "utm_term" "utm_content" "gclid" "fbclid" "ref")

--- a/sites/meridian-advisory.com/src/pages/insights/[...slug].astro
+++ b/sites/meridian-advisory.com/src/pages/insights/[...slug].astro
@@ -45,6 +45,8 @@ const dateFmt = new Intl.DateTimeFormat('en-GB', {
   ctaText="Request a briefing"
   ctaHref="/contact/"
   designTokens={CORPORATE}
+  ogType="article"
+  rssUrl="/rss.xml"
 >
   <div class="container">
     <Breadcrumb

--- a/sites/meridian-advisory.com/src/pages/insights/index.astro
+++ b/sites/meridian-advisory.com/src/pages/insights/index.astro
@@ -38,6 +38,7 @@ const dateFmt = new Intl.DateTimeFormat('en-GB', {
   ctaText="Request a briefing"
   ctaHref="/contact/"
   designTokens={CORPORATE}
+  rssUrl="/rss.xml"
 >
   <div class="container">
     <Breadcrumb

--- a/sites/meridian-advisory.com/src/pages/rss.xml.ts
+++ b/sites/meridian-advisory.com/src/pages/rss.xml.ts
@@ -1,0 +1,26 @@
+import type { APIContext } from 'astro';
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import { SITE_NAME, TAGLINE } from '../lib/site-config';
+
+export async function GET(context: APIContext) {
+  const entries = (await getCollection('insights')).sort(
+    (a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf(),
+  );
+
+  return rss({
+    title: `${SITE_NAME} — Insights`,
+    description: TAGLINE,
+    site: context.site ?? 'https://www.meridian-advisory.com',
+    items: entries.map((entry) => ({
+      title: entry.data.title,
+      description: entry.data.summary,
+      pubDate: entry.data.publishedAt,
+      author: entry.data.author,
+      link: `/insights/${entry.id}/`,
+      categories: entry.data.tags,
+    })),
+    customData: '<language>en-gb</language>',
+    trailingSlash: true,
+  });
+}

--- a/sites/olive-and-vine.com/public/_headers
+++ b/sites/olive-and-vine.com/public/_headers
@@ -1,0 +1,12 @@
+# Cloudflare Pages / Netlify-compatible headers
+# See https://developers.cloudflare.com/pages/configuration/headers/
+
+# Astro emits hashed filenames under /_astro/ (including fonts under /_astro/fonts/).
+# Hashed URLs are safe to cache forever — content changes ⇒ filename changes.
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Keep UTM + ad-click tracking params out of the CDN cache key so a single cached
+# response is served regardless of marketing attribution.
+/*
+  No-Vary-Search: params=("utm_source" "utm_medium" "utm_campaign" "utm_term" "utm_content" "gclid" "fbclid" "ref")

--- a/sites/starter/public/_headers
+++ b/sites/starter/public/_headers
@@ -1,0 +1,12 @@
+# Cloudflare Pages / Netlify-compatible headers
+# See https://developers.cloudflare.com/pages/configuration/headers/
+
+# Astro emits hashed filenames under /_astro/ (including fonts under /_astro/fonts/).
+# Hashed URLs are safe to cache forever — content changes ⇒ filename changes.
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Keep UTM + ad-click tracking params out of the CDN cache key so a single cached
+# response is served regardless of marketing attribution.
+/*
+  No-Vary-Search: params=("utm_source" "utm_medium" "utm_campaign" "utm_term" "utm_content" "gclid" "fbclid" "ref")


### PR DESCRIPTION
## Summary

Executes the **P0 + P1** items from the SEO audit against `SEOHead.astro`, the four sites, and Meridian's new insights collection. P2 items are documented in `docs/seo-recipes.md` rather than baked in.

## What changed

**`packages/shared-ui/src/components/SEOHead.astro`**

- Emits full robots directives (`index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1`) on indexable pages; `noindex, nofollow` on opted-out pages
- Suppresses canonical when `noindex=true` — two contradictory signals hurt rankings
- `og:image` now includes `width`, `height`, and `alt`; only emits when an image is actually supplied (no more broken fallback to a non-existent `/images/og-default.png`)
- `twitter:card` defaults to `summary_large_image` when an `og:image` is present
- Drops meta keywords emission — kept the prop accepted with `@deprecated` so page call sites don't break
- Declares `<link rel="icon" href="/favicon.svg">` — every site ships one but nothing referenced it
- Auto-generates a linked `WebSite` + `Organization` JSON-LD `@graph` from props: `siteName`, `Astro.site`, `logoSrc`, and `socialLinks` (derived as `sameAs`). User-supplied `structuredData` merges into the same graph so `@id` refs resolve. Opt out via `skipAutoJsonLd`.
- New pass-through props on `BaseLayout`: `ogImageAlt`, `ogType`, `twitterHandle`, `noindex`, `rssUrl`, `skipAutoJsonLd`

**`sites/*/public/_headers`**

- 1-year immutable cache on `/_astro/*` (covers hashed JS, CSS, and fonts under `/_astro/fonts/`)
- `No-Vary-Search` on `/` to strip UTM + ad-click params from the CDN cache key

**`sites/meridian-advisory.com`**

- `@astrojs/rss` + `/rss.xml` endpoint generated from the insights collection
- Insights pages pass `rssUrl="/rss.xml"` so `<link rel="alternate" type="application/rss+xml">` appears in head
- Insight detail pages emit `og:type=article`

**`docs/seo-recipes.md` (new)**

Documents the P2 items — per-page OG images (Satori + Sharp), git-based sitemap lastmod, `llms.txt`, markdown alternates, IndexNow, FuzzyRedirect, view transitions, schema endpoints, NLWeb, build-time validation. Linked from README and CLAUDE.md.

## Why these specifically

All baked-in items ride on code the starter already has (a shared `SEOHead` component, `socialLinks` already in every site-config) and pay off on every site without user action. The P2 items need either extra deps (satori/sharp), per-site content structure decisions (which collections to emit as `llms.txt`), or an opinionated UX choice (view transitions) — so they belong in docs, not defaults.

## Test plan

- [x] `bun run build --force` — all 4 sites build clean from scratch
- [x] Meridian home emits a valid linked JSON-LD `@graph` (WebSite + Organization with `@id` refs and `sameAs` from social links)
- [x] Insights pages emit full robots directives, correct canonical, and `<link rel="alternate" type="application/rss+xml">`
- [x] `/rss.xml` produces valid RSS with 3 items, correct pubDates, author, categories
- [x] `_headers` copied into each site's `dist/` at build
- [ ] Validate one insight page in [Google Rich Results Test](https://search.google.com/test/rich-results) after deploy
- [ ] Verify Cloudflare Pages honours the `/_astro/*` immutable rule (network tab after deploy)

## Follow-ups (not in this PR)

- Per-page OG image generation (documented as P2 #1 recipe; reasonable next PR)
- Git-based sitemap lastmod (P2 #2 recipe; nice for Meridian once the insights collection grows)