### PR TITLE
feat(shared-ui): site-wide search, and four more production sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ Thumbs.db
 
 # Internal docs (not published to the repo)
 .internal/
+
+# Written by packages/shared-ui/scripts/search-index.mjs so `astro dev` can
+# serve it. The authoritative copy is written into dist/ by the build.
+sites/*/public/search-index.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,108 +1,577 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (claude.ai/code) working in this repository.
 
-## Project Overview
+This file is written to be **executed, not just read**. Someone clones this repo,
+opens Claude Code, and says "build me a site for acme.com". Everything needed to
+take that from nothing to a live, indexed, measured website is below, in the
+order it has to happen.
 
-Astro Fleet is a multi-site Astro monorepo for agencies and multi-brand companies. Each site lives in `sites/<domain>/` and is independently deployable. Shared components and config live in `packages/`.
+If you are that someone: you do not need to read this file. Tell Claude what you
+want. Claude reads it.
 
-**Stack:** Astro 6, Bun, Turborepo 2, Tailwind CSS 4, TypeScript (strict mode). Static-first — zero client-side JS by default. Fonts are self-hosted via the Astro 6 Fonts API (configured in each site's `astro.config.mjs`, no third-party Google Fonts requests).
+---
 
-## Commands
+## 0. What this repo is
+
+A multi-site Astro monorepo. Each site lives in `sites/<domain>/` and deploys
+independently. Shared components and design tokens live in `packages/`.
+
+**Stack:** Astro 6, Bun, Turborepo 2, Tailwind CSS 4, TypeScript strict.
+Static-first, zero client JS by default. Fonts self-hosted via the Astro Fonts
+API — no third-party font requests at runtime.
+
+**The three demo sites** (`meridian-advisory.com`, `flux-analytics.com`,
+`olive-and-vine.com`) are not templates to copy. They are worked examples
+proving the same components can produce genuinely different-looking sites. Read
+them for technique; do not clone their look.
+
+---
+
+## 1. Before the first site: prerequisites
+
+Check these before doing anything else. Do not assume; run the checks.
+
+```bash
+bun --version        # 1.1+.  Install: curl -fsSL https://bun.sh/install | bash
+node --version       # 20+.   Some tooling still shells out to node.
+git --version
+```
+
+Then:
+
+```bash
+bun install
+bun run build        # must pass before you change anything
+```
+
+**If the baseline build fails, stop and fix that first.** Never start a new site
+on a broken tree — you will spend an hour deciding whether you broke it.
+
+### Deployment prerequisites (only needed at §7)
+
+```bash
+npx wrangler --version    # bundled; no global install needed
+npx wrangler login        # opens a browser, authorises this machine
+```
+
+`wrangler login` is right for a human at a keyboard. For CI, or where no browser
+is available, use an API token:
+
+```bash
+export CLOUDFLARE_API_TOKEN=...     # dashboard -> My Profile -> API Tokens
+export CLOUDFLARE_ACCOUNT_ID=...    # any zone's overview page, right column
+```
+
+The token needs **Account → Cloudflare Pages → Edit**, plus **Zone → DNS → Edit**
+for any domain you will attach.
+
+**Never commit either value.** Shell profile, a gitignored `.env`, or your CI's
+secret store. If a user pastes a token into the chat, use it for the task and
+tell them to rotate it if it has been shared anywhere else.
+
+---
+
+## 2. The conversation that starts a site
+
+You need five things. Ask for all of them in **one message**, then stop asking
+and start building.
+
+1. **Domain** — the real one, e.g. `acme.com`. Becomes the folder name.
+2. **What the business does**, in their words. One or two sentences.
+3. **Who is buying**, and what you want that person to do on the site.
+4. **Any existing brand** — logo, colours, fonts, a site to match.
+5. **Pages needed**, and where the content comes from.
+
+**Do not ask about** palette, type pairing, layout, spacing, animation,
+component choice, section order, or schema types. Those are your job. Decide,
+write one line in an `ASSUMPTIONS.md` at the site root, and keep moving.
+
+If the user is vague, take the most commercially sensible reading and say which
+one you took. A site that exists and is 80% right beats a questionnaire.
+
+---
+
+## 3. Scaffolding
+
+```bash
+./scripts/new-site.sh acme.com corporate    # or: saas | warm
+bun install                                  # ALWAYS after scaffolding
+```
+
+The preset only seeds design tokens. It is a starting point you will change, not
+a decision you are stuck with.
+
+```
+sites/acme.com/
+  astro.config.mjs        site URL, integrations, fonts
+  package.json            scripts; add the search-index step here (§6.1)
+  src/lib/site-config.ts  identity, navigation, footer, contact, social
+  src/pages/              routes
+  src/styles/global.css   Tailwind @theme layer mirroring the tokens
+  public/                 static assets, robots.txt
+```
+
+**Set the real domain in `astro.config.mjs` immediately.** Canonicals, the
+sitemap and OG URLs all derive from it, and a placeholder there poisons all
+three quietly.
+
+---
+
+## 4. Design direction
+
+The failure mode is not ugliness. It is genericness — a site that could belong to
+any company in any industry.
+
+### Choose from the subject
+
+Before picking colours, write one sentence naming what the business actually does
+and what its world looks like. A structural-steel fabricator, a paediatric dental
+practice and a fintech API are three different visual worlds. **If your direction
+would work equally well for all three, it is wrong.**
+
+### What to avoid
+
+These read as machine-generated because they are everywhere:
+
+- Warm cream `#F4F1EA` + serif display + terracotta accent
+- Near-black + one acid-green or vermilion pop
+- Purple-to-blue gradient hero on white
+- Inter or Space Grotesk as the safe default face
+- Emoji as section markers
+- Everything centred
+- `rounded-lg` on every surface with a soft drop shadow
+- An accent bar down the left of a rounded card
+
+If the user explicitly asks for one of these, give it to them — their words win.
+Where nothing is specified, do not spend the freedom on a default.
+
+### Tokens
+
+Edit `src/lib/site-config.ts` (identity, navigation) and the site's `global.css`
+`@theme` block (the Tailwind side). **Keep the two in step** — they are
+duplicated by design, and a mismatch is a real bug visible in only one of them.
+
+Set a type scale and stay on it. Keep running text near 65 characters. Give
+headings `text-wrap: balance`. Uppercase labels get letter-spacing.
+
+### Floors, never traded away
+
+- **WCAG AA contrast.** 4.5:1 body, 3:1 large text — measured against the
+  background the text is *actually composited on*, not the one you assume. A
+  colour that passes on white can fail on the panel it really sits on.
+- **Visible keyboard focus** on every interactive element.
+- **`prefers-reduced-motion` respected.** Anything that would animate shows in
+  its finished state instead.
+- **Nothing hidden by CSS awaiting JavaScript.** If a script fails the page must
+  still read. Set animation start states at run time, not in the stylesheet.
+- **Mobile first.** Check 375px before 1440px.
+- **No horizontal scroll at any width.** Wide things — tables, code, diagrams —
+  scroll inside their own `overflow-x: auto` container.
+
+---
+
+## 5. Content and copy
+
+Copy is design material, not filler. Write it as you build; never ship lorem.
+
+- **Never fabricate proof.** No invented testimonials, client names, user counts,
+  statistics, certifications or awards. Where proof is needed but not supplied,
+  write `[CLIENT TO SUPPLY: ...]` and list every one at handoff.
+- **Name things the way the reader does**, not the way the system is built. A
+  person manages *notifications*, not *webhook config*.
+- **One primary action per page**, with a specific verb. Never "Learn more" as
+  the primary CTA.
+- **Buttons say what happens.** "Publish", then a toast saying "Published".
+- **Errors say what went wrong and how to fix it.** No apologies, no vagueness.
+- **Standard things get standard names.** The blog is called Blog and the pricing
+  page is called Pricing. Save the house voice for headings; a reader hunting for
+  the blog scans for the word "blog".
+
+---
+
+## 6. Features, and how to turn each on
+
+Everything is opt-in. Nothing turns itself on.
+
+### 6.1 Site search
+
+Two steps. **Both are required, and skipping the first fails silently** — the box
+appears and finds nothing.
+
+**Step 1** — add the index generator to the site's build, after `astro build`:
+
+```json
+{
+  "scripts": {
+    "build": "astro build && node ../../packages/shared-ui/scripts/search-index.mjs"
+  }
+}
+```
+
+**Step 2** — turn it on in the layout:
+
+```astro
+<BaseLayout
+  search
+  searchPlaceholder="Pricing, integrations, security"
+  ...
+>
+```
+
+Name three things the site actually covers. A generic placeholder teaches nobody
+what to type.
+
+The index is built from the HTML that actually shipped, so a page whose copy
+changed cannot go missing from search, and a page that never rendered cannot
+appear in it. Fetched on first use, never on load. Roughly 1.8 KB gzipped per
+page. `noindex` pages and the 404 are skipped.
+
+It also writes a copy into `public/` so `astro dev` can serve it — dev serves
+`public/`, not `dist/`. **Gitignore that copy:**
+
+```
+sites/*/public/search-index.json
+```
+
+Keyboard: `/` or Cmd/Ctrl-K opens, arrows move, Enter follows, Escape closes and
+returns focus to the control that opened it.
+
+Full reference including the nine CSS custom properties that restyle the panel:
+`docs/components.md` → SiteSearch.
+
+### 6.2 Analytics, behind consent
+
+```astro
+<BaseLayout
+  gaId="G-XXXXXXXXXX"
+  privacyHref="/privacy/"
+  ...
+>
+```
+
+That is the whole integration. What it does:
+
+- **Nothing is requested from Google until the visitor accepts.** Deliberately
+  stricter than the usual Consent Mode v2 pattern, which loads `gtag.js`
+  immediately with tracking denied and flips it later — that still fetches
+  Google's script and still pings before anybody has agreed.
+- Global Privacy Control is read as a decline; the banner never shows.
+- The choice is stored in `localStorage` under `analytics-consent`. Pages on the
+  same origin share it, so nobody is asked twice.
+- `window.track(name, params)` is available everywhere and is a no-op until
+  consent, so callers never have to check.
+
+**Update the privacy page in the same commit.** The most common mistake in this
+whole repo's history is a privacy page describing analytics the site does not
+have — or, worse, promising a consent banner that was never built. If you want
+the standard behaviour instead, pass `requireConsent={false}` and say *that*.
+
+The honest trade: **your numbers will be lower than a site that tags everyone.**
+They will also match what your privacy page says.
+
+### 6.3 SEO
+
+Most of it is automatic once `site` is correct in `astro.config.mjs`. Per page,
+`BaseLayout` emits a unique title and meta description, canonical, Open Graph and
+Twitter tags, and JSON-LD from `structuredData`.
+
+**What you still have to do:**
+
+- One `<h1>` per page, and a heading tree that descends in order.
+- A real, distinct `description` per page. Under 160 characters or it truncates.
+- Descriptive `alt` on every image. Decorative images get `alt=""`.
+- Deliberate internal linking. Every page reachable, and pointing somewhere
+  useful.
+- `structuredData` where a type genuinely applies: `Organization`, `Product`,
+  `Article`, `FAQPage`, `BreadcrumbList`. Do not invent schema that does not fit.
+
+**Recipes for the rest** — per-page OG images, git-based sitemap `lastmod`,
+`llms.txt` for answer engines, IndexNow, markdown alternates, fuzzy 404
+redirects, build-time validation — are in `docs/seo-recipes.md`. Read it before
+writing any of that yourself.
+
+**Write for answer engines too.** Answer-first sections, real FAQs, consistent
+entity naming, and factual statements an AI could quote without mangling.
+
+---
+
+## 7. Deployment
+
+### 7.1 Build and look at it locally
+
+```bash
+bun run build --filter=acme.com
+cd sites/acme.com && npx astro preview
+```
+
+### 7.2 Create the Pages project (once per site)
+
+```bash
+npx wrangler pages project create acme-com --production-branch=main
+```
+
+Project names cannot contain dots. Convention: `acme.com` → `acme-com`.
+
+### 7.3 Deploy
+
+```bash
+# staging first, always
+npx wrangler pages deploy sites/acme.com/dist --project-name=acme-com \
+  --branch=staging --commit-dirty=true
+
+# then production
+npx wrangler pages deploy sites/acme.com/dist --project-name=acme-com \
+  --branch=main --commit-dirty=true
+```
+
+Staging gets a `staging.<project>.pages.dev` alias. Look at it on the real CDN
+before production — some faults only appear behind a proxy.
+
+### 7.4 Attach the custom domain
+
+**Wrangler cannot do this.** There is no `pages domain` command. Use the
+dashboard (Workers & Pages → project → Custom domains) or the API:
+
+```bash
+curl -sS -X POST \
+  "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/acme-com/domains" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{"name":"acme.com"}'
+```
+
+Repeat for `www.acme.com`.
+
+**The trap.** If a conflicting DNS record already exists — say an `A` record
+pointing at an old host — Cloudflare will **not** overwrite it. The domain sits
+at `status: pending` forever, the certificate never issues, and nothing reports
+an error. Check, then fix the records explicitly:
+
+```bash
+# find the record id
+curl -sS "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records?name=acme.com" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+
+# point it at Pages
+curl -sS -X PUT \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records/$RECORD_ID" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{"type":"CNAME","name":"acme.com","content":"acme-com.pages.dev","proxied":true,"ttl":1}'
+```
+
+**Before touching DNS on a domain already in use, write the current records down
+somewhere recoverable.** Apex `CNAME` flattening means `MX` records keep working,
+so mail survives an apex change — but change only the records you mean to, and
+check the rest afterwards.
+
+### 7.5 Purge the cache
+
+After any deploy that changes HTML, or you will spend twenty minutes debugging a
+stale page:
+
+```bash
+curl -sS -X POST "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/purge_cache" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  -H "Content-Type: application/json" --data '{"purge_everything":true}'
+```
+
+### 7.6 Other hosts
+
+Vercel, Netlify and self-hosted Traefik + Caddy are all supported and documented
+in `docs/deployment.md`. The build output is plain static files; nothing here is
+Cloudflare-specific except §7.2 to §7.5.
+
+---
+
+## 8. Verify before saying it is done
+
+Never report a site as finished from the source. Look at what actually rendered.
+At minimum, against the built output:
+
+- [ ] Every page returns 200. Walk the sitemap.
+- [ ] **No horizontal scroll** at 1280, 768, 375 and 320.
+- [ ] **Contrast passes** on every text element, measured against its real
+      composited background.
+- [ ] No broken images — check `naturalWidth === 0`, not just that the file
+      exists.
+- [ ] Keyboard: tab through, focus always visible, nothing traps.
+- [ ] Search returns sensible results for three real queries, if enabled.
+- [ ] Consent: **zero requests to googletagmanager before accepting**, and the
+      tag loads after. If analytics is enabled.
+- [ ] Canonical, title and description correct and unique on every page.
+- [ ] `robots.txt` and the sitemap present and reachable.
+- [ ] If this replaces an existing site: every indexed old URL has a 301, or the
+      rankings go on launch day.
+
+Report what you measured, with numbers. "Contrast passes" is worth less than
+"lowest reading on the site is 4.99:1 against a 4.5 floor".
+
+---
+
+## 9. Failure modes seen in the wild
+
+Every one of these has shipped silently in a real project. They are listed
+because **none of them produce an error**.
+
+**An undefined CSS custom property deletes the whole declaration.**
+`font-size: var(--t-5)` where `--t-5` was never defined is *invalid at computed
+value time*. It does not fall back to the previous rule — the property is dropped
+and the element inherits. Symptom: headings render at body size. A typo in a
+custom property is not a syntax error.
+
+**A reset that outranks the flow rhythm.** `figure` has a browser default margin.
+Killing it with `.card { margin: 0 }` scores the same as
+`* + .card { margin-top: 2rem }` and, sitting later in the file, wins. Symptom:
+everything is flush. Write resets inside `:where()` so they score zero.
+
+**A broad descendant selector claiming a component.** `.menu a { color: … }`
+scores 0,1,1 and beats `.btn` at 0,1,0, so the button inside your menu is
+repainted in link colour. Use `:not(.btn)`.
+
+**`getStaticPaths` cannot see its own frontmatter.** Astro hoists it into a
+separate module scope, so a `const` declared beside it is out of scope. It fails
+at generate time, not type-check time, and reads like a typo. Declare inside the
+function, or import it.
+
+**A redirect splat shadowing real routes.** Cloudflare evaluates `_redirects`
+before serving a file, so `/blog/*  /  301` makes every blog post unreachable.
+List specific redirects; never splat a prefix you also serve.
+
+**Search that returns nothing in development.** `astro dev` serves `public/`, not
+`dist/`. Without the dev copy the box works and finds nothing, silently.
+
+**A nowrap column holding prose.** A cell styled `white-space: nowrap` so numbers
+never break mid-figure will push the whole page sideways the moment somebody puts
+a sentence or a street address in it.
+
+**Trailing-slash mismatches in redirects.** If the old sitemap publishes `/post/`
+and your rule says `/post`, whether it matches is a platform detail. Write both.
+
+**Cloudflare email obfuscation rewriting your HTML.** Scrape Shield turns
+`hello@acme.com` into `[email protected]` in the served markup, decoded by a
+script at run time. Fine for humans, invisible to AI crawlers reading your
+contact page. Decide deliberately; it is on by default.
+
+---
+
+## 10. Commands
 
 ```bash
 # Development
-bun run dev                                    # all sites (port 4321)
-bun run dev --filter=<domain>                  # single site
-bun run dev --filter=<domain> -- --port 4322   # custom port
+bun run dev                                    # all sites (4321)
+bun run dev --filter=acme.com                  # one site
+bun run dev --filter=acme.com -- --port 4322   # a second alongside
 
 # Build
-bun run build                                  # all sites (parallel via Turborepo)
-bun run build --filter=<domain>                # single site
+bun run build                                  # all, parallel via Turborepo
+bun run build --filter=acme.com                # one
 
-# Lint
+# Lint / typecheck
 bun run lint
 
-# Scaffold a new site
-./scripts/new-site.sh <domain> [corporate|saas|warm]
-bun install  # run after scaffolding
+# New site
+./scripts/new-site.sh acme.com corporate       # then: bun install
 
-# Deploy (Cloudflare Pages)
-wrangler pages deploy sites/<domain>/dist --project-name=<name> --branch=main
+# Search index (only if not already in the site's build script)
+cd sites/acme.com && node ../../packages/shared-ui/scripts/search-index.mjs
+
+# Deploy
+npx wrangler pages deploy sites/acme.com/dist --project-name=acme-com --branch=main
 
 # Self-hosted infra
-./scripts/setup-infra.sh domain1.com,domain2.com
+./scripts/setup-infra.sh acme.com,other.com
 ```
 
-## Architecture
+---
 
-### Monorepo layout
+## 11. Architecture reference
+
+### Layout
 
 ```
-packages/config/       — DesignTokens interface + 3 presets (CORPORATE, SAAS, WARM)
-packages/shared-ui/    — 22 shared components + 3 layouts (BaseLayout, IndustryLayout, ProductLayout)
-sites/<domain>/        — individual sites, each with its own astro.config, package.json, and pages
-scripts/               — new-site.sh (scaffolder), setup-infra.sh (Docker/Traefik)
-infrastructure/        — Docker Compose + Traefik + Caddy templates
+packages/config/       DesignTokens interface + 3 presets (CORPORATE, SAAS, WARM)
+packages/shared-ui/    24 components + 3 layouts + scripts/search-index.mjs
+sites/<domain>/        one site; own astro.config, package.json, pages
+scripts/               new-site.sh, setup-infra.sh
+infrastructure/        Docker Compose + Traefik + Caddy templates
 ```
 
-### Design token system
+### Design tokens
 
-Tokens are defined as TypeScript objects (`packages/config/src/tokens.ts`) conforming to the `DesignTokens` interface. They get converted to CSS custom properties two ways:
+Defined in `packages/config/src/tokens.ts` against the `DesignTokens` interface,
+reaching CSS two ways:
 
-1. **`tokensToCSSVars()`** in `packages/config/src/css.ts` — called by BaseLayout, injected into `:root` at build time
-2. **`global.css` `@theme` layer** — each site duplicates token values for Tailwind CSS 4 integration
+1. `tokensToCSSVars()` in `packages/config/src/css.ts`, called by `BaseLayout`,
+   injected into `:root` at build time.
+2. Each site's `global.css` `@theme` layer, for Tailwind 4.
 
-CSS variables: `--color-primary`, `--color-secondary`, `--color-accent`, `--color-bg`, `--color-text`, `--color-cta`, `--font-heading`, `--font-body`, `--hero-layout`, `--cta-style`, `--spacing`
+Variables: `--color-primary`, `--color-secondary`, `--color-accent`,
+`--color-bg`, `--color-text`, `--color-cta`, `--font-heading`, `--font-body`,
+`--hero-layout`, `--cta-style`, `--spacing`.
 
 ### Per-site configuration
 
-Each site has a single `src/lib/site-config.ts` that defines: site name, tagline, logo, navigation menu (with dropdown support), footer columns, contact info, and social links. Reading this one file gives full context on a site's identity.
+One file, `src/lib/site-config.ts`: site name, tagline, logo, navigation (with
+dropdowns), footer columns, contact info, social links. Reading it gives full
+context on a site's identity.
+
+### Component conventions
+
+Everything in `packages/shared-ui/src/components/`:
+
+- Exports a typed `Props` interface. No `any`.
+- Uses CSS custom properties for all colours and fonts, so it is preset-agnostic.
+- Scoped `<style>` blocks. Where a component must ship global CSS, it wraps every
+  rule in `:where()` so a site's own stylesheet always wins without `!important`.
+- No hardcoded content — props or named slots.
+- `loading="lazy"` on images, `aria-*` on interactive elements.
+- Import path: `@astro-fleet/shared-ui/src/components/<Name>.astro`
+
+To change a component for one site, **copy it into that site's
+`src/components/` and edit there.** Do not fork a shared component in place —
+the other sites are using it.
 
 ### Page pattern
 
-Pages import `BaseLayout` from `@astro-fleet/shared-ui`, a preset from `@astro-fleet/config/tokens`, and site config from `../lib/site-config`. All content is passed via typed props — no global state.
+A page imports `BaseLayout` from `@astro-fleet/shared-ui`, a preset from
+`@astro-fleet/config/tokens`, and site config from `../lib/site-config`. All
+content passed via typed props; no global state.
+`sites/meridian-advisory.com/src/pages/index.astro` is the canonical shape.
 
-## Component Conventions
+---
 
-All shared components in `packages/shared-ui/src/components/`:
+## 12. Repository workflow
 
-- Export a typed `Props` interface — no `any` types
-- Use CSS custom properties for all colors/fonts (preset-agnostic)
-- Scoped `<style>` blocks — no global CSS side effects
-- No hardcoded content — everything via props or named slots
-- `loading="lazy"` on images, `aria-*` on interactive elements
-- Import path: `@astro-fleet/shared-ui/src/components/<Name>.astro`
+- **`main` is protected.** All changes go through a feature branch and a PR.
+- **Conventional commits:** `feat:`, `fix:`, `docs:`, `chore:`.
+- **CI** runs `bun install --frozen-lockfile` and `bun run build` on every PR.
+- **Deploy after merge**, per site, as in §7.
 
-## Workflow
+---
 
-- **Branch protection:** `main` is protected. All changes go through feature branches and PRs.
-- **Commit messages:** conventional commits — `feat:`, `fix:`, `docs:`, `chore:`
-- **CI:** GitHub Actions runs `bun install --frozen-lockfile` + `bun run build` on every PR.
-- **Deploys:** after merging, deploy individual sites with `wrangler pages deploy sites/<domain>/dist --project-name=<name> --branch=main`
+## 13. Further reading
 
-## Key Files to Know
+| Doc | For |
+|---|---|
+| `docs/getting-started.md` | Clone to first deploy in 15 minutes |
+| `docs/adding-a-site.md` | `site-config.ts` in full, selective builds |
+| `docs/components.md` | All 24 components and 3 layouts, with props |
+| `docs/design-tokens.md` | The token system and the three presets |
+| `docs/seo-recipes.md` | OG images, llms.txt, IndexNow, validation |
+| `docs/deployment.md` | Cloudflare, Vercel, Netlify, self-hosted |
+| `docs/adding-a-cms.md` | The Keystatic pattern and alternatives |
+| `docs/framework-integrations.md` | React/Vue/Svelte islands, view transitions |
+| `docs/ai-workflow.md` | Sample prompts and AI-driven development patterns |
 
-- `packages/config/src/tokens.ts` — DesignTokens interface + CORPORATE/SAAS/WARM presets
-- `packages/config/src/css.ts` — `tokensToCSSVars()` utility
-- `packages/shared-ui/src/layouts/BaseLayout.astro` — main page shell (composes SEOHead, Header, Footer)
-- `packages/shared-ui/src/components/` — all 22 shared components
-- `sites/<domain>/src/lib/site-config.ts` — site identity config (single file controls entire site brand)
-- `sites/<domain>/src/styles/global.css` — Tailwind imports + `@theme` layer with token values
-- `sites/<domain>/astro.config.mjs` — per-site Astro config (update `site` URL for each domain)
+### Key files
+
+- `packages/config/src/tokens.ts` — presets
+- `packages/config/src/css.ts` — `tokensToCSSVars()`
+- `packages/shared-ui/src/layouts/BaseLayout.astro` — the page shell
+- `packages/shared-ui/scripts/search-index.mjs` — the search index generator
+- `sites/<domain>/src/lib/site-config.ts` — one file controls a site's brand
+- `sites/<domain>/src/styles/global.css` — Tailwind `@theme` token mirror
+- `sites/<domain>/astro.config.mjs` — per-site config; **set `site`**
 - `.github/workflows/ci.yml` — CI pipeline
-- `.github/pull_request_template.md` — PR template
-
-## Detailed Documentation
-
-For in-depth guidance beyond what's in this file, refer to:
-
-- [docs/components.md](docs/components.md) — Props interfaces, usage examples, CSS variables, and recipes for all 22 components and 3 layouts
-- [docs/getting-started.md](docs/getting-started.md) — Clone to first deploy in 15 minutes
-- [docs/adding-a-site.md](docs/adding-a-site.md) — Scaffold, configure, and deploy a new site
-- [docs/adding-a-cms.md](docs/adding-a-cms.md) — Keystatic pattern used in Meridian, access-control caveats, and alternatives
-- [docs/seo-recipes.md](docs/seo-recipes.md) — Optional SEO add-ons not baked into the starter (per-page OG images, git-based lastmod, llms.txt, markdown alternates, IndexNow, FuzzyRedirect, view transitions)
-- [docs/design-tokens.md](docs/design-tokens.md) — How presets work, creating custom palettes
-- [docs/framework-integrations.md](docs/framework-integrations.md) — Adding React/Vue/Svelte, Islands Architecture, View Transitions, Content Collections, and other Astro 6 capabilities
-- [docs/deployment.md](docs/deployment.md) — Cloudflare Pages, Vercel, Netlify, or self-hosted
-- [docs/ai-workflow.md](docs/ai-workflow.md) — Sample prompts and AI-driven development patterns

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ _More coming soon._ If you ship a site with Astro Fleet, open a PR adding it her
 
 ## Quick Start
 
+**Building with Claude Code?** Clone the repo and read
+[Build a site with Claude](docs/build-a-site-with-claude.md). It walks from
+`git clone` to a live domain, with the exact things to type at each step.
+`CLAUDE.md` is the agent's copy of the same process, and Claude reads it
+automatically.
+
 **The fastest way — scaffold a new fleet with the CLI:**
 
 ```bash
@@ -92,7 +98,7 @@ bun install
 
 ## What's Included
 
-- **22 shared components + 3 layouts** — Header, Footer, SEO Head, CTA blocks, cards, forms, testimonials, breadcrumbs, pricing tables, FAQ accordions, team grids, timelines, hero sliders, section dividers, comparison tables, and more. All accept content via typed props, all use CSS variables for theming.
+- **24 shared components + 3 layouts** — Header, Footer, SEO Head, CTA blocks, cards, forms, testimonials, breadcrumbs, pricing tables, FAQ accordions, team grids, timelines, hero sliders, section dividers, comparison tables, and more. All accept content via typed props, all use CSS variables for theming.
 - **Design token system** — 3 presets (Corporate, SaaS, Warm) with a TypeScript interface. Create custom presets or modify colors and fonts per site without touching component code.
 - **Site scaffolder** — Either `bunx create-astro-fleet` (cross-platform, interactive prompts) or `./scripts/new-site.sh domain.com [preset]` (bash) creates a new site from the starter template with the correct config, styles, and build pipeline wired up.
 - **CMS-ready** — Meridian demo ships with [Keystatic](https://keystatic.com) wired up for editable content. Admin at `/keystatic` in dev, content committed as markdown. See [Adding a CMS](docs/adding-a-cms.md) for the pattern and alternatives.
@@ -103,6 +109,7 @@ bun install
 
 ## Documentation
 
+- [Build a site with Claude](docs/build-a-site-with-claude.md) — Clone to live domain with Claude Code, step by step
 - [Getting Started](docs/getting-started.md) — Clone to first deploy in 15 minutes
 - [Adding a Site](docs/adding-a-site.md) — Create and configure additional sites
 - [Adding a CMS](docs/adding-a-cms.md) — Keystatic pattern used in Meridian, plus when to pick a different CMS

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Each demo composes the **same shared components** (`Header`, `Footer`, `ServiceC
 
 Real sites running in production on the same codebase as the demos above:
 
+- **[edubold.com](https://www.edubold.com)** — School management ERP for Indian schools and trusts: admissions, fees, payroll, and double-entry accounts on one set of records
 - **[moiengineering.com](https://www.moiengineering.com)** — Packaging and wrapping machinery, and a parts catalogue going back to 1960 (Mohali, India)
 - **[hybridagrobots.com](https://www.hybridagrobots.com)** — Computer-vision grading and sorting machines for agriculture and poultry
 - **[indivar.com](https://www.indivar.com)** — Independent technology consulting: architecture, cloud, and delivery

--- a/README.md
+++ b/README.md
@@ -47,9 +47,14 @@ Each demo composes the **same shared components** (`Header`, `Footer`, `ServiceC
 
 Real sites running in production on the same codebase as the demos above:
 
-- **[vairi.com](https://www.vairi.com)** — AI-enhanced software development and business automation consultancy (Auckland, NZ)
-- **[claspt.app](https://www.claspt.app)** — Encrypted markdown notes and password vault, available on the Microsoft Store, macOS, and Linux
+- **[moiengineering.com](https://www.moiengineering.com)** — Packaging and wrapping machinery, and a parts catalogue going back to 1960 (Mohali, India)
+- **[hybridagrobots.com](https://www.hybridagrobots.com)** — Computer-vision grading and sorting machines for agriculture and poultry
+- **[indivar.com](https://www.indivar.com)** — Independent technology consulting: architecture, cloud, and delivery
 - **[stakteck.com](https://www.stakteck.com)** — IT staffing, contract hiring, and staff augmentation across India
+- **[vairi.com](https://www.vairi.com)** — AI-enhanced software development and business automation consultancy (Auckland, NZ)
+- **[claspt.app](https://www.claspt.app)** — Encrypted markdown notes and password vault, on the Microsoft Store, macOS, and Linux
+
+Every URL above was checked and returned 200 on 22 August 2026.
 
 _More coming soon._ If you ship a site with Astro Fleet, open a PR adding it here — we'd love to feature it.
 

--- a/docs/build-a-site-with-claude.md
+++ b/docs/build-a-site-with-claude.md
@@ -1,0 +1,288 @@
+# Build a site with Claude
+
+A walkthrough from cloning this repo to a live, measured website. Written for
+the person at the keyboard, not for the agent — `CLAUDE.md` is the agent's copy.
+
+You do not need to know Astro. You do need to read what Claude tells you and
+answer five questions honestly.
+
+**Roughly an hour**, most of it spent looking at the site and asking for changes.
+
+---
+
+## Before you start
+
+Install these once:
+
+| | Check | If missing |
+|---|---|---|
+| **Bun** | `bun --version` (1.1+) | `curl -fsSL https://bun.sh/install \| bash` |
+| **Node** | `node --version` (20+) | [nodejs.org](https://nodejs.org) |
+| **Claude Code** | `claude --version` | [claude.com/code](https://claude.com/code) |
+
+A **Cloudflare account** is needed only at the deploy step, and it is free. You
+do not need one to build and look at a site.
+
+Then:
+
+```bash
+git clone https://github.com/Indivar/astro-fleet.git
+cd astro-fleet
+bun install
+bun run build     # should pass; if not, say so before going further
+claude
+```
+
+That last command opens Claude Code in the repo. Everything below is typed into
+that conversation.
+
+---
+
+## Step 1 — Ask for the site
+
+Type something like this. Detail helps; polish does not.
+
+> Build me a site for **acme.com**. We fabricate structural steel for commercial
+> builders in Auckland. The buyer is a project manager comparing three
+> fabricators on lead time and certification. I want them to request a quote.
+> We have a logo at `~/Desktop/acme-logo.svg` and no other brand. Pages: home,
+> capabilities, projects, certifications, about, contact.
+
+Claude will confirm the five things it needs and start. If you leave something
+out it will ask **once**, in one message, then get on with it.
+
+**It will not ask you about colours, fonts, layout or spacing.** Those are its
+job. It records what it assumed in `sites/acme.com/ASSUMPTIONS.md` so you can
+argue with any of it later.
+
+### If you have an existing site
+
+> Look at oldacme.com and carry over the real content. Keep every page that
+> ranks. Tell me what you find that we should not repeat.
+
+Claude will fetch it, and will tell you where the old copy makes claims it
+cannot verify.
+
+---
+
+## Step 2 — Look at it
+
+```
+Show me the site
+```
+
+Claude starts a dev server and gives you a URL. **Open it.** Then say what is
+wrong, in your own words:
+
+> The hero is too big and the headline is doing nothing. The three service cards
+> look like every consulting site I have seen.
+
+Vague is fine. "It feels generic" is a useful sentence — genericness is a real
+fault with real causes, and Claude has a list of them.
+
+**Ask for alternatives** rather than accepting the first answer:
+
+> Show me three different directions for the homepage hero. Do not use the same
+> layout three times.
+
+---
+
+## Step 3 — Turn on what you want
+
+Each of these is one instruction. None is on by default.
+
+### Search across the whole site
+
+```
+Add site search
+```
+
+Two files change, and search costs nothing on page load — the index is fetched
+the first time somebody actually searches. Visitors press `/` or `Cmd-K`.
+
+Worth asking for once it is in:
+
+> Search for "lead time" and show me what comes back
+
+### Google Analytics
+
+First create a GA4 property at [analytics.google.com](https://analytics.google.com)
+— Admin → Create → Property → Web → copy the `G-XXXXXXXXXX`. Then:
+
+```
+Add GA4, the ID is G-XXXXXXXXXX
+```
+
+You get a consent banner, and **nothing is sent to Google until a visitor
+accepts.** That is stricter than most sites. It means your numbers will be lower
+than a site that tracks everyone, and it means your privacy page is true.
+
+Claude will also update your privacy page to match. Let it — a privacy page
+describing analytics you do not have is the single most common fault in this
+whole area.
+
+> Prefer the standard behaviour? Say "use standard consent mode" and Claude will
+> switch it, and change the privacy wording to match.
+
+### SEO
+
+Mostly automatic. Worth asking for explicitly:
+
+```
+Do a full SEO pass and tell me what you changed
+```
+
+That covers per-page titles and descriptions, structured data, `llms.txt` so AI
+search engines can read the site, per-page social cards, and sitemap `lastmod`
+from git history.
+
+### A blog
+
+```
+Add a blog with pagination and an archive by year
+```
+
+Ask for images in the index and a sidebar if you want them; say so up front.
+
+---
+
+## Step 4 — Check it honestly
+
+Before deploying:
+
+```
+Verify the site properly and show me the numbers
+```
+
+Claude checks the built output, not the source: every page loads, nothing scrolls
+sideways on a phone, contrast passes against real backgrounds, no broken images,
+keyboard navigation works.
+
+**Ask for numbers, not adjectives.** "Contrast passes" means less than "the
+lowest reading on the site is 4.99:1 against a 4.5 floor". If you get adjectives,
+ask again.
+
+---
+
+## Step 5 — Deploy
+
+### Connect Cloudflare, once
+
+In your terminal:
+
+```
+! npx wrangler login
+```
+
+The `!` runs it in the Claude Code session, so Claude sees the result. A browser
+opens; approve it. This machine is now authorised and you will not do it again.
+
+> **Automating this later?** Create an API token instead: Cloudflare dashboard →
+> My Profile → API Tokens, with **Account → Cloudflare Pages → Edit** and
+> **Zone → DNS → Edit**. Put it in your shell profile as
+> `CLOUDFLARE_API_TOKEN`. **Never commit it.**
+
+### Deploy to staging
+
+```
+Deploy to staging
+```
+
+You get a `.pages.dev` URL. Look at it. Some faults appear only behind a real
+CDN.
+
+### Go live
+
+```
+Deploy to production and point acme.com at it
+```
+
+Claude deploys, attaches the domain, and updates DNS.
+
+**Two things to know**, both real:
+
+- **If the domain already points somewhere**, Cloudflare will not overwrite the
+  existing record. The certificate silently never issues. Claude checks for this
+  and fixes the record explicitly — but say so if the domain is currently live:
+
+  > acme.com is currently serving our old WordPress site. Record the current DNS
+  > before you change anything.
+
+- **Email is not affected** by pointing the apex at Pages. `MX` records are
+  separate. Claude will confirm this rather than assume it.
+
+### Replacing an existing site?
+
+Say so **before** deploying:
+
+> This replaces our WordPress site. Make sure every indexed URL still works.
+
+Claude fetches the old sitemap and writes a redirect for every URL. Skip this and
+you lose your search rankings on launch day, quietly, and find out weeks later.
+
+---
+
+## Adding more sites
+
+The repo holds as many as you like:
+
+```
+Add a second site for acmeparts.co.nz. Same company, different business,
+so it should not look like acme.com.
+```
+
+Shared components are shared; the look is not. Deploy them independently.
+
+---
+
+## Useful things to say
+
+| Say this | To get |
+|---|---|
+| `Show me three directions for this page` | Alternatives instead of the first idea |
+| `That looks generic. Why?` | A diagnosis, not a reskin |
+| `What did you assume?` | The assumptions log |
+| `What do you need from me?` | Blockers only you can clear |
+| `What is not finished?` | An honest list, including anything skipped |
+| `Check this on a phone` | 375px, measured |
+| `Deploy to staging first` | A look before it is public |
+
+---
+
+## When something goes wrong
+
+**The build fails.** Paste the error. Claude reads build output better than it
+reads descriptions of build output.
+
+**A page looks broken.** Screenshot it. Say which browser and roughly how wide
+the window was.
+
+**Search finds nothing.** Almost always the index step missing from the build
+script. Say `search returns nothing` and Claude will check that first.
+
+**Analytics shows no data.** GA's Home tab lags by a day or two. Look at
+**Reports → Realtime** instead. If Realtime is empty, say so and Claude will
+check whether the tag is actually firing.
+
+**The site is live but shows the old version.** Cloudflare's edge cache. Say
+`purge the cache`.
+
+---
+
+## What this does not do
+
+Being straight about the edges:
+
+- **No CMS by default.** Content lives in the repo, and you change it by asking
+  Claude or editing files. If a non-technical person must edit copy without a
+  developer, ask for a CMS — `docs/adding-a-cms.md` covers the pattern.
+- **No e-commerce.** Static sites, no cart, no checkout.
+- **No logo design.** Bring a logo, or get one made.
+- **No stock photography.** Claude will not invent images, and will not pretend
+  a stock photo is your factory. Supply real photographs or the site ships
+  without them.
+- **No invented proof.** Claude will not write testimonials, client names, user
+  counts or statistics you have not given it. Where a page needs proof you have
+  not supplied, it writes `[CLIENT TO SUPPLY: ...]` and lists them at handoff.
+  That is a feature. Made-up numbers are the fastest way to lose a buyer who
+  checks.

--- a/docs/components.md
+++ b/docs/components.md
@@ -29,6 +29,7 @@ import ComponentName from '@astro-fleet/shared-ui/src/components/ComponentName.a
 | [SectionDivider](#sectiondivider) | Decorative SVG wave/curve shapes (6 presets) | No |
 | [SEOHead](#seohead) | All `<head>` SEO tags: OG, Twitter Card, JSON-LD, canonical | No |
 | [ServiceCard](#servicecard) | Service offering card with icon slot and arrow link | No |
+| [SiteSearch](#sitesearch) | Search across every page, from a build-time index | Deferred |
 | [StatsBar](#statsbar) | Horizontal metrics strip (dark/light) | No |
 | [TeamGrid](#teamgrid) | People cards with photo fallback, bio, social links | No |
 | [TestimonialSlider](#testimonialslider) | Horizontal testimonial carousel with star ratings | Minimal |
@@ -1299,6 +1300,93 @@ import TrustBar from '@astro-fleet/shared-ui/src/components/TrustBar.astro';
 ```
 
 **CSS variables consumed:** `--color-primary`, `--color-accent`, `--font-body`
+
+---
+
+### SiteSearch
+
+Search across every page of a site, with no server and no search service.
+
+The index is built from the HTML that actually shipped, so a page whose copy
+changed cannot then be missing from search, and a page that never rendered
+cannot appear in it. It is fetched on first use and never on load, so search
+costs nothing on the critical path.
+
+Deliberately not a search library. A dependency that ships a WebAssembly
+runtime and its own index format earns its size at a few thousand pages. On a
+forty-page marketing site it would be most of the JavaScript on the page.
+
+**Two steps. Both are required, and the order matters.**
+
+1. Add the index generator to the site's build, after `astro build`:
+
+   ```json
+   {
+     "scripts": {
+       "build": "astro build && node ../../packages/shared-ui/scripts/search-index.mjs"
+     }
+   }
+   ```
+
+2. Turn it on in the layout:
+
+   ```astro
+   <BaseLayout
+     search
+     searchPlaceholder="Pricing, integrations, security"
+     ...
+   >
+   ```
+
+A search box without step 1 returns nothing at all, silently, which is why it
+is off by default.
+
+**Props**
+
+| Prop | Type | Default | Notes |
+|------|------|---------|-------|
+| `search` | `boolean` | `false` | Shows the search control in the header |
+| `searchPlaceholder` | `string` | `'Search this site'` | Name three things the site actually covers. A generic placeholder teaches nobody what to type |
+
+**Generator options**
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--dist <dir>` | `dist` | Where the build is |
+| `--public <dir>` | `public` | Dev copy, so `astro dev` can serve it. Gitignore this file |
+| `--exclude a,b` | `/lab/` | Extra path prefixes to leave out |
+| `--body <n>` | `1200` | Characters of body text kept per page |
+
+Pages carrying `<meta name="robots" content="noindex">` and the 404 are skipped:
+if it is not for search engines it is not for the reader either.
+
+**Keyboard.** `/` or Cmd/Ctrl-K opens it, arrows move through results, Enter
+follows the highlighted one, Escape closes and returns focus to the control
+that opened it.
+
+**Styling.** Every rule in the component is wrapped in `:where()`, so it scores
+zero specificity and your own stylesheet always wins without `!important`. Set
+these on `.srch` to restyle the panel:
+
+```css
+.srch {
+  --search-bg:     #fff;
+  --search-bg-2:   #f6f7f9;   /* hovered and selected rows */
+  --search-ink:    #111;
+  --search-ink-3:  #555;      /* snippets */
+  --search-ink-4:  #888;      /* placeholder, result count */
+  --search-rule:   #ddd;
+  --search-accent: #0066cc;   /* icons, rails, selected marker */
+  --search-mono:   ui-monospace, monospace;
+  --search-scrim:  rgb(15 23 42 / 0.45);
+}
+```
+
+Sizes are literal pixels rather than tokens from the type scale. Search chrome
+is interface, and a display-scale token here will set a result title at 49px.
+
+**Size.** The index is roughly 1.8 KB gzipped per page: 18 KB for a
+thirty-three page site, 12 KB for eight pages.
 
 ---
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,6 +1,6 @@
 # Components Reference
 
-Astro Fleet ships **22 components** and **3 layouts** in `packages/shared-ui/`. Every component is self-contained: typed Props, scoped styles, CSS custom properties for theming, and zero third-party dependencies. Import them using the `@astro-fleet/shared-ui` workspace alias.
+Astro Fleet ships **24 components** and **3 layouts** in `packages/shared-ui/`. Every component is self-contained: typed Props, scoped styles, CSS custom properties for theming, and zero third-party dependencies. Import them using the `@astro-fleet/shared-ui` workspace alias.
 
 ```astro
 ---
@@ -29,6 +29,7 @@ import ComponentName from '@astro-fleet/shared-ui/src/components/ComponentName.a
 | [SectionDivider](#sectiondivider) | Decorative SVG wave/curve shapes (6 presets) | No |
 | [SEOHead](#seohead) | All `<head>` SEO tags: OG, Twitter Card, JSON-LD, canonical | No |
 | [ServiceCard](#servicecard) | Service offering card with icon slot and arrow link | No |
+| [Analytics](#analytics) | GA4 behind a consent banner; nothing loads until accepted | Deferred |
 | [SiteSearch](#sitesearch) | Search across every page, from a build-time index | Deferred |
 | [StatsBar](#statsbar) | Horizontal metrics strip (dark/light) | No |
 | [TeamGrid](#teamgrid) | People cards with photo fallback, bio, social links | No |
@@ -385,7 +386,7 @@ import FAQ from '@astro-fleet/shared-ui/src/components/FAQ.astro';
     },
     {
       question: 'Do components require client-side JavaScript?',
-      answer: 'Almost none. 20 of 22 components are pure CSS. Only HeroSlider and TestimonialSlider include a small inline script for carousel navigation.',
+      answer: 'Almost none. 20 of 24 components are pure CSS. HeroSlider and TestimonialSlider carry a small inline script for carousel navigation, and SiteSearch and Analytics load nothing until the visitor uses them.',
     },
   ]}
 />
@@ -1303,6 +1304,98 @@ import TrustBar from '@astro-fleet/shared-ui/src/components/TrustBar.astro';
 
 ---
 
+### Analytics
+
+Google Analytics 4 behind a consent banner, with the tag loading only after the
+visitor accepts.
+
+**Why this is stricter than usual.** The common pattern is Consent Mode v2: load
+`gtag.js` immediately with `analytics_storage: denied`, then flip it to granted.
+That still fetches Google's script and still sends cookieless pings before
+anybody has agreed to anything.
+
+Most privacy policies do not describe that. They say something closer to
+"analytics runs only if you agree, and if you decline it does not load". This
+component keeps that sentence literally: **nothing is requested from
+googletagmanager.com until the visitor accepts.** Consent Mode defaults are still
+set before the script arrives, because a granted signal needs something to
+update.
+
+The trade is worth stating up front: **your numbers will be lower than a site
+that tags everyone.** They will also match what your privacy page says.
+
+**Usage**
+
+```astro
+<BaseLayout
+  gaId="G-XXXXXXXXXX"
+  privacyHref="/privacy/"
+  ...
+>
+```
+
+That is the whole integration. Omit `gaId` and nothing renders at all.
+
+**Props**
+
+| Prop | Type | Default | Notes |
+|------|------|---------|-------|
+| `gaId` | `string` | — | GA4 Measurement ID. Omit and no analytics renders |
+| `privacyHref` | `string` | `'/privacy/'` | Where your analytics and cookies section lives |
+
+On the component directly (if you mount it outside `BaseLayout`):
+
+| Prop | Type | Default | Notes |
+|------|------|---------|-------|
+| `id` | `string` | — | The Measurement ID |
+| `policyHref` | `string` | `'/privacy/'` | Link in the banner |
+| `requireConsent` | `boolean` | `true` | `false` loads the tag immediately. Say so on your privacy page |
+| `storageKey` | `string` | `'analytics-consent'` | Change it to re-ask everybody after a policy change |
+
+**Behaviour**
+
+- Global Privacy Control is read as a decline, and the banner never shows.
+- The choice is stored in `localStorage`. Pages on the same origin share it, so
+  a visitor is never asked twice — including a hand-built static page that sets
+  the same key.
+- `window.track(name, params)` is available on every page and is a **no-op until
+  consent**, so callers never have to check. Events are not queued and replayed:
+  an event about what somebody did before they agreed is still an event about
+  what they did before they agreed.
+
+**Named events**
+
+```js
+window.track('generate_lead', { form: 'quote' });
+```
+
+`generate_lead` is GA4's own name for a form submission, so it lands in the
+standard reports rather than needing a custom definition.
+
+**Styling**
+
+Every rule is wrapped in `:where()`, so it scores zero specificity and your own
+stylesheet always wins without `!important`. Set these on `.cons`:
+
+```css
+.cons {
+  --consent-bg:     #16233A;
+  --consent-ink:    #EDF1EC;   /* buttons, borders */
+  --consent-ink-3:  #C9D6E4;   /* body text */
+  --consent-accent: #4FC6F2;   /* the policy link */
+  --consent-width:  1320px;    /* matches your content width */
+  --consent-gut:    24px;
+  --consent-scrim:  rgb(15 23 42 / 0.45);
+}
+```
+
+**Update your privacy page in the same commit.** A privacy page describing
+analytics behaviour the site does not have is the most common fault in this
+area, and the version that promises a consent banner that was never built is the
+worst of them.
+
+---
+
 ### SiteSearch
 
 Search across every page of a site, with no server and no search service.
@@ -1591,14 +1684,22 @@ Add comments to any page via the `footer-scripts` slot:
 - **Disqus**: Add the Disqus universal embed code.
 - **Cusdis**: Lightweight, privacy-first alternative.
 
-### Analytics
+### Other analytics providers
 
-Use the `footer-scripts` slot in BaseLayout:
+**For Google Analytics, use the built-in [Analytics](#analytics) component**
+rather than pasting a gtag snippet. It handles consent, and it will not leave
+your privacy page describing something the site does not do.
 
-- **Plausible** (recommended — privacy-first, no cookie banner needed): `<script defer data-domain="yourdomain.com" src="https://plausible.io/js/script.js"></script>`
-- **Fathom**: Similar to Plausible, single script tag.
-- **Google Analytics 4**: Standard gtag.js snippet.
-- **PostHog**: Full product analytics with session replay.
+For anything else, use the `footer-scripts` slot in BaseLayout:
+
+- **Plausible** — privacy-first and cookieless, so no consent banner is needed:
+  `<script defer data-domain="yourdomain.com" src="https://plausible.io/js/script.js"></script>`
+- **Fathom** — similar to Plausible, single script tag.
+- **PostHog** — full product analytics with session replay. Sets cookies, so it
+  needs consent handling of its own.
+
+Whichever you pick, **say on your privacy page what it actually does.** If it
+sets a cookie, say so. If it needs consent, ask for it.
 
 ### Forms
 

--- a/docs/framework-integrations.md
+++ b/docs/framework-integrations.md
@@ -1,6 +1,6 @@
 # Framework Integrations & Astro Capabilities
 
-Astro Fleet's 22 shared components are built as native `.astro` files — pure HTML templates with scoped CSS and zero framework dependencies. This is a deliberate choice: it means you can use **any** UI framework alongside them, or none at all.
+Astro Fleet's 24 shared components are built as native `.astro` files — pure HTML templates with scoped CSS and zero framework dependencies. This is a deliberate choice: it means you can use **any** UI framework alongside them, or none at all.
 
 This guide covers how to add interactive framework components to your Fleet sites, and how to take advantage of Astro's broader feature set.
 
@@ -164,7 +164,7 @@ If you build a React/Vue/Svelte component that multiple sites need, you have two
 
 ### Option 1: Add to shared-ui (recommended for Astro components)
 
-If the component is an `.astro` file (or can be), add it to `packages/shared-ui/src/components/`. This is the simplest path — it works exactly like the existing 22 components.
+If the component is an `.astro` file (or can be), add it to `packages/shared-ui/src/components/`. This is the simplest path — it works exactly like the existing 24 components.
 
 ### Option 2: Create a new shared package (for framework components)
 

--- a/packages/shared-ui/scripts/search-index.mjs
+++ b/packages/shared-ui/scripts/search-index.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * The search index, shared by every site in the fleet.
+ *
+ * Built from the HTML that actually shipped, not from the source. A page whose
+ * copy changed cannot then be missing from search, and a page that never
+ * rendered cannot appear in it.
+ *
+ * Deliberately not a search library. These sites run from a dozen to forty
+ * pages. A dependency that ships a WebAssembly runtime and its own index
+ * format earns its size at a few thousand pages; here it would be most of the
+ * JavaScript on sites whose floor is LCP under 2.5s on a mid-range phone.
+ * The index is a JSON file, fetched on first use and never on load.
+ *
+ * Run it AFTER `astro build`, from the site directory:
+ *
+ *   node ../../packages/shared-ui/scripts/search-index.mjs
+ *
+ * Then add it to the site's build script, after the Astro build:
+ *
+ *   "build": "astro build && node ../../packages/shared-ui/scripts/search-index.mjs"
+ *
+ * Options, all optional:
+ *   --dist <dir>     where the build is           (default: dist)
+ *   --public <dir>   dev copy, so `astro dev` can serve it  (default: public)
+ *   --exclude a,b    extra path prefixes to leave out
+ *   --body <n>       characters of body text kept per page  (default: 1200)
+ */
+import { readdirSync, readFileSync, writeFileSync, statSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const arg = (name, fallback) => {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+};
+
+const DIST = arg('dist', 'dist');
+const PUBLIC = arg('public', 'public');
+const BODY_CHARS = Number(arg('body', '1200'));
+const EXCLUDE = ['/lab/', ...arg('exclude', '').split(',').filter(Boolean)];
+
+function htmlFiles(dir) {
+  return readdirSync(dir).flatMap((name) => {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) return htmlFiles(p);
+    return name.endsWith('.html') ? [p] : [];
+  });
+}
+
+/** Visible words only: no script, style, nav, header or footer. */
+function visible(html) {
+  let h = html.replace(/<(script|style|nav|header|footer)\b[^>]*>[\s\S]*?<\/\1>/gi, ' ');
+  h = h.replace(/<[^>]+>/g, ' ');
+  h = h.replace(/&rsquo;|&#8217;/g, "'").replace(/&amp;/g, '&').replace(/&nbsp;/g, ' ');
+  h = h.replace(/&[a-z]+;|&#\d+;/gi, ' ');
+  return h.replace(/\s+/g, ' ').trim();
+}
+
+const attr = (html, re) => (html.match(re) || [, ''])[1];
+
+if (!existsSync(DIST)) {
+  console.error(`search-index: no ${DIST}/ directory. Run this after astro build.`);
+  process.exit(1);
+}
+
+const docs = [];
+for (const file of htmlFiles(DIST)) {
+  const url = '/' + file.replace(`${DIST}/`, '').replace(/index\.html$/, '').replace(/\.html$/, '');
+  if (url === '/404' || EXCLUDE.some((p) => url.startsWith(p))) continue;
+
+  const html = readFileSync(file, 'utf8');
+  // If it is not for search engines it is not for the reader either.
+  if (/<meta\s+name="robots"[^>]*noindex/i.test(html)) continue;
+
+  const h1 = visible(attr(html, /<h1[^>]*>([\s\S]*?)<\/h1>/i) || '');
+  const title = h1 || visible(attr(html, /<title>([\s\S]*?)<\/title>/i) || '');
+  const desc = attr(html, /<meta\s+name="description"\s+content="([^"]*)"/i);
+  // The section label in the margin, where a site has one.
+  const rail = visible(attr(html, /<p class="rail"[^>]*>([\s\S]*?)<\/p>/i) || '');
+  const heads = [...html.matchAll(/<h([23])[^>]*>([\s\S]*?)<\/h\1>/gi)]
+    .map((m) => visible(m[2]))
+    .filter(Boolean);
+
+  /* The body is capped. Past roughly 1,200 characters a page matches on its
+     own footnotes and the index doubles for results nobody scrolls to. */
+  const body = visible(html).slice(0, BODY_CHARS);
+
+  docs.push({ u: url, t: title, d: desc, r: rail, h: heads.slice(0, 12), b: body });
+}
+
+docs.sort((a, b) => a.u.localeCompare(b.u));
+const json = JSON.stringify(docs);
+
+writeFileSync(join(DIST, 'search-index.json'), json);
+
+/* Also into public/, because `astro dev` serves from there and not from dist.
+   Without it the search box in development returns nothing at all, silently,
+   which is exactly the kind of fault that ships. Gitignore this copy. */
+if (existsSync(PUBLIC)) writeFileSync(join(PUBLIC, 'search-index.json'), json);
+
+const kb = (Buffer.byteLength(json) / 1024).toFixed(1);
+console.log(`search-index: ${docs.length} page(s), ${kb} KB`);

--- a/packages/shared-ui/src/components/Analytics.astro
+++ b/packages/shared-ui/src/components/Analytics.astro
@@ -1,0 +1,194 @@
+---
+/**
+ * Google Analytics 4, gated on consent.
+ *
+ * WHY THE SCRIPT IS NOT LOADED UP FRONT.
+ *
+ * The usual pattern is Consent Mode v2: load gtag.js immediately with
+ * `analytics_storage: denied`, then flip it to granted once somebody agrees.
+ * That still loads Google's script and still sends cookieless pings before
+ * anybody has agreed to anything.
+ *
+ * Most privacy policies do not describe that. They say something closer to
+ * "analytics runs only if you agree to it, and if you decline it does not
+ * load". This component keeps that sentence literally: nothing from
+ * googletagmanager.com is requested until the visitor accepts. Consent Mode
+ * defaults are still set before the script arrives, because a granted signal
+ * has to have something to update.
+ *
+ * The consequence is honest and worth stating up front: your numbers will be
+ * lower than a site that tags everyone. They will also match what your privacy
+ * page says, which is the point.
+ *
+ * If you would rather have the standard behaviour, pass
+ * `requireConsent={false}` and say so on your privacy page.
+ *
+ * Costs nothing on the critical path. The banner is markup already in the
+ * page, the decision is read from localStorage, and gtag is injected after
+ * the page is interactive.
+ *
+ * STYLING. Every rule is wrapped in `:where()`, so it scores zero specificity
+ * and a site's own stylesheet always wins with no `!important`. Colours come
+ * from custom properties with fallbacks.
+ */
+export interface Props {
+  /** The Measurement ID, G-XXXXXXXXXX. Omit and nothing renders at all. */
+  id?: string;
+  /** Where the cookie and analytics section lives. */
+  policyHref?: string;
+  /** Ask before loading. Leave true unless a policy says otherwise. */
+  requireConsent?: boolean;
+  /** Storage key. Change it to re-ask everybody after a policy change. */
+  storageKey?: string;
+}
+
+const {
+  id,
+  policyHref = '/privacy/',
+  requireConsent = true,
+  storageKey = 'analytics-consent',
+} = Astro.props;
+---
+
+{id && (
+  <div
+    class="cons"
+    data-analytics
+    data-ga-id={id}
+    data-require-consent={requireConsent ? 'yes' : 'no'}
+    data-storage-key={storageKey}
+    hidden
+  >
+    <div class="cons__in" role="region" aria-label="Analytics consent">
+      <p class="cons__t">
+        We would like to count which pages people read, using Google Analytics. It tells us
+        nothing about who you are, and the site works exactly the same if you say no.
+        <a href={policyHref}>What we collect</a>
+      </p>
+      <div class="cons__b">
+        <button class="cons__no" type="button" data-consent="denied">No thanks</button>
+        <button class="cons__yes" type="button" data-consent="granted">Allow</button>
+      </div>
+    </div>
+  </div>
+)}
+
+<style is:global>
+  :where(.cons) {
+    position: fixed; left: 0; right: 0; bottom: 0; z-index: 180;
+    background: var(--consent-bg, #fff);
+    border-top: 1px solid var(--consent-ink, #111);
+  }
+  :where(.cons__in) {
+    max-width: var(--consent-width, 1320px); margin: 0 auto;
+    padding: 14px var(--consent-gut, 20px);
+    display: flex; flex-wrap: wrap; gap: 12px 24px; align-items: center;
+  }
+  :where(.cons__t) {
+    margin: 0; flex: 1 1 22rem; min-width: 0;
+    font-size: 15px; line-height: 1.5; color: var(--consent-ink-3, #444);
+  }
+  :where(.cons__t a) { color: var(--consent-accent, #06c); }
+  :where(.cons__b) { display: flex; gap: 10px; flex: 0 0 auto; }
+  :where(.cons__yes), :where(.cons__no) {
+    font-family: inherit; font-size: 14.5px; font-weight: 600;
+    padding: 9px 18px; cursor: pointer; min-height: 42px;
+    border: 1px solid var(--consent-ink, #111);
+  }
+  :where(.cons__yes) { background: var(--consent-ink, #111); color: var(--consent-bg, #fff); }
+  :where(.cons__no)  { background: transparent; color: var(--consent-ink, #111); }
+  :where(.cons__yes:hover) { background: transparent; color: var(--consent-ink, #111); }
+  :where(.cons__no:hover)  { background: var(--consent-ink, #111); color: var(--consent-bg, #fff); }
+</style>
+
+<script>
+  /**
+   * `window.track(name, params)` is available on every page, whether or not
+   * consent was given. Before consent it is a no-op rather than a queue: an
+   * event queued and replayed after somebody agrees is still an event about
+   * what they did before they agreed.
+   */
+  declare global {
+    interface Window {
+      dataLayer: unknown[];
+      gtag: (...args: unknown[]) => void;
+      track: (name: string, params?: Record<string, unknown>) => void;
+    }
+  }
+
+  let loaded = false;
+
+  function loadGtag(id: string) {
+    if (loaded) return;
+    loaded = true;
+
+    window.dataLayer = window.dataLayer || [];
+    window.gtag = function gtag() { window.dataLayer.push(arguments); };
+
+    // Set before the script arrives, so the granted signal has something to
+    // update rather than racing it.
+    window.gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'denied',
+      wait_for_update: 500,
+    });
+    window.gtag('js', new Date());
+    window.gtag('config', id, { anonymize_ip: true });
+    window.gtag('consent', 'update', { analytics_storage: 'granted' });
+
+    const s = document.createElement('script');
+    s.async = true;
+    s.src = 'https://www.googletagmanager.com/gtag/js?id=' + encodeURIComponent(id);
+    document.head.appendChild(s);
+  }
+
+  function wire() {
+    const root = document.querySelector<HTMLElement>('[data-analytics]');
+    window.track = window.track || function () {};
+    if (!root || root.dataset.wired) return;
+    root.dataset.wired = 'yes';
+
+    const id = root.dataset.gaId || '';
+    const key = root.dataset.storageKey || 'analytics-consent';
+    const needsConsent = root.dataset.requireConsent !== 'no';
+
+    const read = () => { try { return localStorage.getItem(key); } catch { return null; } };
+    const write = (v: string) => { try { localStorage.setItem(key, v); } catch { /* private mode */ } };
+
+    const start = () => {
+      loadGtag(id);
+      window.track = (name, params) => {
+        try { window.gtag('event', name, params || {}); } catch { /* blocked */ }
+      };
+    };
+
+    if (!needsConsent) { start(); return; }
+
+    /* Global Privacy Control is a legal signal in some places and a clear
+       statement of preference everywhere. Treated as a decline, and the
+       banner is never shown. */
+    if ((navigator as { globalPrivacyControl?: boolean }).globalPrivacyControl === true) {
+      write('denied');
+      return;
+    }
+
+    const decided = read();
+    if (decided === 'granted') { start(); return; }
+    if (decided === 'denied') return;
+
+    root.hidden = false;
+    root.querySelectorAll<HTMLButtonElement>('[data-consent]').forEach((b) => {
+      b.addEventListener('click', () => {
+        const choice = b.dataset.consent === 'granted' ? 'granted' : 'denied';
+        write(choice);
+        root.hidden = true;
+        if (choice === 'granted') start();
+      });
+    });
+  }
+
+  wire();
+  document.addEventListener('astro:page-load', wire);
+</script>

--- a/packages/shared-ui/src/components/Header.astro
+++ b/packages/shared-ui/src/components/Header.astro
@@ -5,6 +5,8 @@ export interface MenuItem {
   children?: MenuItem[];
 }
 
+import SiteSearch from './SiteSearch.astro';
+
 export interface Props {
   navigation: MenuItem[];
   logoSrc?: string;
@@ -12,6 +14,15 @@ export interface Props {
   siteName: string;
   ctaText?: string;
   ctaHref?: string;
+  /**
+   * Site-wide search. Off by default, because it needs an index: add
+   * `node ../../packages/shared-ui/scripts/search-index.mjs` to the site's
+   * build script after `astro build`, then set this. A search box with no
+   * index silently returns nothing, which is worse than no search box.
+   */
+  search?: boolean;
+  /** Name three things this site actually covers. Generic placeholders teach nobody what to type. */
+  searchPlaceholder?: string;
 }
 
 const {
@@ -21,6 +32,8 @@ const {
   siteName,
   ctaText = 'Get Started',
   ctaHref = '/contact',
+  search = false,
+  searchPlaceholder = 'Search this site',
 } = Astro.props;
 
 const currentPath = Astro.url.pathname;
@@ -79,6 +92,8 @@ const currentPath = Astro.url.pathname;
       </ul>
 
       <!-- CTA Button (Desktop) -->
+      {search && <SiteSearch placeholder={searchPlaceholder} class="header__search" />}
+
       <a href={ctaHref} class="header__cta">{ctaText}</a>
 
       <!-- Mobile Menu Toggle (CSS checkbox hack) -->

--- a/packages/shared-ui/src/components/SiteSearch.astro
+++ b/packages/shared-ui/src/components/SiteSearch.astro
@@ -1,0 +1,348 @@
+---
+/**
+ * Search, across a whole site. Shared by every site in this monorepo.
+ *
+ * How it behaves, and why:
+ *
+ * - The index is fetched on FIRST USE, never on load. Nothing about search is
+ *   on the critical path, so it cannot cost the LCP budget.
+ * - It is a dialog, not a page. A search that navigates away loses the
+ *   reader's place, and most searches end in one click.
+ * - Every token must match (AND, not OR). On a forty-page site an OR search
+ *   returns most of the site and ranks it, which reads as "no results" with
+ *   extra steps.
+ * - Matching is by word start, so "attend" finds "attendance" but "tax" does
+ *   not find "syntax". No stemmer: these vocabularies are small and known.
+ * - Ranked by WHERE the match is. A word in the heading is a stronger signal
+ *   than the same word in the ninth paragraph.
+ *
+ * Keyboard: "/" or Cmd/Ctrl-K opens, Escape closes, up and down move through
+ * results, Enter follows the highlighted one. Focus returns to the control
+ * that opened it, which is the part most search overlays get wrong.
+ *
+ * No script means no search button, rather than a button that does nothing:
+ * it renders hidden and is revealed by the script that makes it work.
+ *
+ * STYLING. Every rule below is wrapped in `:where()`, so it scores zero and a
+ * site's own stylesheet always wins without needing `!important`. Colours come
+ * from custom properties with fallbacks, so a site can restyle the whole panel
+ * by setting five values. Class names are stable: `.srch`, `.srch__open`,
+ * `.srch__box`, `.srch__bar`, `.srch__in`, `.srch__note`, `.srch__res`,
+ * `.srch__r`, `.srch__t`, `.srch__s`.
+ *
+ * Sizes are literal pixels, on purpose. Search chrome is interface. Reaching
+ * for a site's display scale set one result title at 49px and made a single
+ * result 242px tall.
+ */
+export interface Props {
+  /** Where the index lives. Written there by scripts/search-index.mjs. */
+  indexUrl?: string;
+  /** Shown in the empty field. Name three things this site actually covers. */
+  placeholder?: string;
+  /** Text on the button. Hidden below 700px, where the icon carries it. */
+  label?: string;
+  class?: string;
+}
+
+const {
+  indexUrl = '/search-index.json',
+  placeholder = 'Search this site',
+  label = 'Search',
+  class: cls = '',
+} = Astro.props;
+---
+
+<button class:list={['srch__open', cls]} type="button" data-search-open hidden aria-haspopup="dialog">
+  <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
+    <circle cx="11" cy="11" r="7"></circle><path d="M16.5 16.5 21 21"></path>
+  </svg>
+  <span>{label}</span>
+  <kbd>/</kbd>
+</button>
+
+<div class="srch" data-search data-search-index={indexUrl} hidden>
+  <div class="srch__scrim" data-search-scrim></div>
+  <div class="srch__box" role="dialog" aria-modal="true" aria-label="Search this site">
+    <div class="srch__bar">
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
+        <circle cx="11" cy="11" r="7"></circle><path d="M16.5 16.5 21 21"></path>
+      </svg>
+      <input
+        class="srch__in"
+        type="search"
+        data-search-input
+        placeholder={placeholder}
+        aria-label="Search this site"
+        autocomplete="off"
+        spellcheck="false"
+      />
+      <button class="srch__close" type="button" data-search-close aria-label="Close search">
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
+          <path d="M6 6l12 12M18 6L6 18"></path>
+        </svg>
+      </button>
+    </div>
+    <p class="srch__note" data-search-note aria-live="polite"></p>
+    <ul class="srch__res" data-search-results></ul>
+  </div>
+</div>
+
+<style is:global>
+  /* Zero specificity throughout, so a site's own rules win. */
+  :where(.srch__open) {
+    display: inline-flex; align-items: center; gap: 8px;
+    background: transparent;
+    border: 1px solid var(--search-rule, currentColor);
+    color: var(--search-ink-3, inherit);
+    font-family: inherit; font-size: 14px; font-weight: 400;
+    padding: 8px 12px; cursor: pointer; min-height: 40px;
+    transition: border-color 0.15s, color 0.15s;
+  }
+  :where(.srch__open:hover) { color: var(--search-ink, inherit); }
+  :where(.srch__open kbd) {
+    font-family: var(--search-mono, ui-monospace, monospace);
+    font-size: 11px; line-height: 1.4; padding: 1px 5px;
+    border: 1px solid var(--search-rule, currentColor);
+    color: var(--search-ink-4, inherit);
+  }
+  @media (max-width: 700px) {
+    :where(.srch__open span), :where(.srch__open kbd) { display: none; }
+  }
+
+  :where(.srch) { position: fixed; inset: 0; z-index: 200; }
+  :where(.srch__scrim) { position: absolute; inset: 0; background: var(--search-scrim, rgba(15, 23, 42, 0.45)); }
+  :where(.srch__box) {
+    position: absolute; left: 50%; top: 0; transform: translateX(-50%);
+    width: min(720px, 100%); max-height: 86vh;
+    display: flex; flex-direction: column;
+    background: var(--search-bg, #fff);
+    border: 1px solid var(--search-ink, #111); border-top: 0;
+    animation: srchIn 0.22s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+  @keyframes srchIn { from { opacity: 0; transform: translateX(-50%) translateY(-10px); } }
+
+  :where(.srch__bar) {
+    display: flex; align-items: center; gap: 12px;
+    padding: 12px 24px; border-bottom: 1px solid var(--search-ink, #111);
+  }
+  :where(.srch__bar svg) { color: var(--search-accent, #06c); flex: 0 0 auto; }
+  :where(.srch__in) {
+    flex: 1 1 auto; min-width: 0; border: 0; background: transparent;
+    font-family: inherit; font-weight: 400; font-size: 20px; line-height: 1.4;
+    color: var(--search-ink, #111); padding: 4px 0;
+  }
+  :where(.srch__in:focus) { outline: none; }
+  :where(.srch__in::placeholder) { color: var(--search-ink-4, #888); }
+  :where(.srch__in::-webkit-search-cancel-button) { display: none; }
+  :where(.srch__close) {
+    background: transparent; border: 0; cursor: pointer;
+    color: var(--search-ink-3, inherit);
+    padding: 6px; min-height: 36px; min-width: 36px;
+    display: inline-flex; align-items: center; justify-content: center;
+  }
+  :where(.srch__close:hover) { color: var(--search-ink, #111); }
+
+  :where(.srch__note) {
+    margin: 0; padding: 9px 24px;
+    font-family: var(--search-mono, ui-monospace, monospace);
+    font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase;
+    color: var(--search-ink-4, #888);
+    border-bottom: 1px solid var(--search-rule, #ddd);
+  }
+
+  :where(.srch__res) { margin: 0; padding: 0; list-style: none; overflow-y: auto; }
+  :where(.srch__res a) {
+    display: block; padding: 13px 24px 14px;
+    border-bottom: 1px solid var(--search-rule, #ddd);
+    color: var(--search-ink, #111); text-decoration: none;
+  }
+  :where(.srch__res a:hover), :where(.srch__res a[data-cur]) { background: var(--search-bg-2, rgba(0, 0, 0, 0.03)); }
+  :where(.srch__res a[data-cur]) { box-shadow: inset 3px 0 0 var(--search-accent, #06c); }
+  :where(.srch__r) {
+    display: block; font-family: var(--search-mono, ui-monospace, monospace);
+    font-size: 11px; letter-spacing: 0.16em; text-transform: uppercase;
+    color: var(--search-accent, #06c);
+  }
+  :where(.srch__t) { display: block; margin-top: 3px; font-size: 17px; font-weight: 500; line-height: 1.35; }
+  :where(.srch__s) {
+    margin-top: 4px; font-size: 14.5px; line-height: 1.5;
+    color: var(--search-ink-3, #555);
+    /* Two lines at most. A third pushes the next result off the screen and
+       nobody reads a snippet to the end. */
+    display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2; overflow: hidden;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    :where(.srch__box) { animation: none; }
+  }
+</style>
+
+<script>
+  type Doc = { u: string; t: string; d: string; r: string; h: string[]; b: string };
+
+  const MAX_RESULTS = 8;
+
+  let docs: Doc[] | null = null;
+  let loading: Promise<void> | null = null;
+  let opener: HTMLElement | null = null;
+  let cursor = -1;
+
+  const load = (url: string) => {
+    if (docs) return Promise.resolve();
+    if (!loading) {
+      loading = fetch(url)
+        .then((r) => (r.ok ? r.json() : []))
+        .then((d) => { docs = d as Doc[]; })
+        .catch(() => { docs = []; });
+    }
+    return loading;
+  };
+
+  const tokens = (q: string) =>
+    q.toLowerCase().split(/[^a-z0-9]+/i).filter((t) => t.length > 1).slice(0, 6);
+
+  /** Word-start match, so "tax" hits "tax" and "taxable" but not "syntax". */
+  const hits = (haystack: string, tok: string) => {
+    let n = 0, i = -1;
+    const h = haystack.toLowerCase();
+    while ((i = h.indexOf(tok, i + 1)) !== -1) {
+      if (i === 0 || !/[a-z0-9]/.test(h[i - 1])) n++;
+    }
+    return n;
+  };
+
+  function search(q: string) {
+    const toks = tokens(q);
+    if (!toks.length || !docs) return [];
+    const out: { doc: Doc; score: number }[] = [];
+
+    for (const doc of docs) {
+      const heads = (doc.h || []).join(' ');
+      let score = 0;
+      let matchedAll = true;
+      for (const tok of toks) {
+        const sub =
+          hits(doc.t || '', tok) * 12 +
+          hits(doc.r || '', tok) * 6 +
+          hits(heads, tok) * 5 +
+          hits(doc.d || '', tok) * 4 +
+          Math.min(hits(doc.b || '', tok), 4);
+        if (!sub) { matchedAll = false; break; }
+        score += sub;
+      }
+      if (matchedAll) {
+        // A page that is not the homepage is usually the more precise answer.
+        if (doc.u === '/') score -= 2;
+        out.push({ doc, score });
+      }
+    }
+    return out.sort((a, b) => b.score - a.score).slice(0, MAX_RESULTS);
+  }
+
+  /** The sentence the match sits in, so the reader sees why it came back. */
+  function snippet(doc: Doc, q: string) {
+    const toks = tokens(q);
+    const hay = doc.d && doc.d.length > 40 ? doc.d : (doc.b || '');
+    const low = hay.toLowerCase();
+    let at = -1;
+    for (const tok of toks) { const i = low.indexOf(tok); if (i !== -1) { at = i; break; } }
+    if (at === -1) return hay.slice(0, 120);
+    const start = Math.max(0, at - 50);
+    return (start ? '…' : '') + hay.slice(start, start + 140).trim() + '…';
+  }
+
+  const esc = (s: string) =>
+    String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+  function wire() {
+    const root = document.querySelector<HTMLElement>('[data-search]');
+    const openBtn = document.querySelector<HTMLElement>('[data-search-open]');
+    if (!root || !openBtn || root.dataset.wired) return;
+    root.dataset.wired = 'yes';
+
+    const indexUrl = root.dataset.searchIndex || '/search-index.json';
+    const input = root.querySelector<HTMLInputElement>('[data-search-input]')!;
+    const list = root.querySelector<HTMLUListElement>('[data-search-results]')!;
+    const note = root.querySelector<HTMLElement>('[data-search-note]')!;
+
+    // Revealed only now, so a reader without JavaScript is never shown a
+    // control that cannot work.
+    openBtn.hidden = false;
+
+    const render = (q: string) => {
+      const results = search(q);
+      cursor = results.length ? 0 : -1;
+      list.innerHTML = results
+        .map((r, i) => `
+          <li>
+            <a href="${esc(r.doc.u)}" ${i === 0 ? 'data-cur' : ''}>
+              <span class="srch__r">${esc(r.doc.r || 'Page')}</span>
+              <span class="srch__t">${esc(r.doc.t)}</span>
+              <span class="srch__s">${esc(snippet(r.doc, q))}</span>
+            </a>
+          </li>`)
+        .join('');
+      note.textContent = !q.trim()
+        ? 'Type to search every page on this site.'
+        : results.length
+          ? `${results.length} result${results.length === 1 ? '' : 's'}.`
+          : 'Nothing matched. Try one word instead of a phrase.';
+    };
+
+    const move = (delta: number) => {
+      const links = [...list.querySelectorAll<HTMLAnchorElement>('a')];
+      if (!links.length) return;
+      links[cursor]?.removeAttribute('data-cur');
+      cursor = (cursor + delta + links.length) % links.length;
+      links[cursor].setAttribute('data-cur', '');
+      links[cursor].scrollIntoView({ block: 'nearest' });
+    };
+
+    const open = (from: HTMLElement | null) => {
+      opener = from;
+      root.hidden = false;
+      document.documentElement.style.overflow = 'hidden';
+      load(indexUrl).then(() => render(input.value));
+      input.focus();
+      render(input.value);
+    };
+
+    const close = () => {
+      root.hidden = true;
+      document.documentElement.style.overflow = '';
+      opener?.focus();
+      opener = null;
+    };
+
+    openBtn.addEventListener('click', () => open(openBtn));
+    root.querySelector('[data-search-close]')?.addEventListener('click', close);
+    root.querySelector('[data-search-scrim]')?.addEventListener('click', close);
+    input.addEventListener('input', () => render(input.value));
+
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowDown') { e.preventDefault(); move(1); }
+      else if (e.key === 'ArrowUp') { e.preventDefault(); move(-1); }
+      else if (e.key === 'Enter') {
+        const cur = list.querySelector<HTMLAnchorElement>('a[data-cur]');
+        if (cur) { e.preventDefault(); window.location.href = cur.href; }
+      }
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (!root.hidden && e.key === 'Escape') { e.preventDefault(); close(); }
+      if (root.hidden) {
+        const el = document.activeElement;
+        const typing = el instanceof HTMLElement &&
+          (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable);
+        if (typing) return;
+        if (e.key === '/' || ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k')) {
+          e.preventDefault();
+          open(el instanceof HTMLElement ? el : openBtn);
+        }
+      }
+    });
+  }
+
+  wire();
+  document.addEventListener('astro:page-load', wire);
+</script>

--- a/packages/shared-ui/src/layouts/BaseLayout.astro
+++ b/packages/shared-ui/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import SEOHead from '../components/SEOHead.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+import Analytics from '../components/Analytics.astro';
 import type { MenuItem } from '../components/Header.astro';
 import type { FooterColumn, ContactInfo, SocialLink } from '../components/Footer.astro';
 import type { DesignTokens } from '@astro-fleet/config';
@@ -51,6 +52,15 @@ export interface Props {
   /** Footer tagline */
   tagline?: string;
   /** Header CTA text */
+  /**
+   * GA4 Measurement ID. Omit and no analytics renders at all.
+   *
+   * The tag loads only after the visitor accepts. See Analytics.astro for why
+   * this is stricter than the usual Consent Mode v2 pattern.
+   */
+  gaId?: string;
+  /** Where your analytics and cookies section lives. */
+  privacyHref?: string;
   /** Site-wide search in the header. Needs the search index in the build. */
   search?: boolean;
   /** Placeholder for the search field. Name three things this site covers. */
@@ -88,6 +98,8 @@ const {
   logoSrc,
   logoAlt,
   tagline,
+  gaId,
+  privacyHref = '/privacy/',
   search,
   searchPlaceholder,
   ctaText,
@@ -299,6 +311,12 @@ const cssVars = designTokens ? tokensToCSSVars(designTokens) : '';
       siteName={siteName}
       tagline={tagline}
     />
+
+    {/* Conditional, so a site with no gaId does not ship the analytics script
+        at all. SiteSearch is rendered the same way in Header for the same
+        reason: Astro tree-shakes a component that is never in the tree, but
+        not one that renders nothing. */}
+    {gaId && <Analytics id={gaId} policyHref={privacyHref} />}
 
     <slot name="footer-scripts" />
   </body>

--- a/packages/shared-ui/src/layouts/BaseLayout.astro
+++ b/packages/shared-ui/src/layouts/BaseLayout.astro
@@ -51,6 +51,10 @@ export interface Props {
   /** Footer tagline */
   tagline?: string;
   /** Header CTA text */
+  /** Site-wide search in the header. Needs the search index in the build. */
+  search?: boolean;
+  /** Placeholder for the search field. Name three things this site covers. */
+  searchPlaceholder?: string;
   ctaText?: string;
   /** Header CTA link */
   ctaHref?: string;
@@ -84,6 +88,8 @@ const {
   logoSrc,
   logoAlt,
   tagline,
+  search,
+  searchPlaceholder,
   ctaText,
   ctaHref,
   bodyClass = '',
@@ -276,6 +282,8 @@ const cssVars = designTokens ? tokensToCSSVars(designTokens) : '';
       siteName={siteName}
       logoSrc={logoSrc}
       logoAlt={logoAlt}
+      search={search}
+      searchPlaceholder={searchPlaceholder}
       ctaText={ctaText}
       ctaHref={ctaHref}
     />

--- a/sites/meridian-advisory.com/package.json
+++ b/sites/meridian-advisory.com/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "astro build && node ../../packages/shared-ui/scripts/search-index.mjs",
     "preview": "astro preview",
     "lint": "astro check"
   },

--- a/sites/meridian-advisory.com/src/pages/404.astro
+++ b/sites/meridian-advisory.com/src/pages/404.astro
@@ -20,6 +20,8 @@ import {
   {contactInfo}
   {socialLinks}
   siteName={SITE_NAME}
+  search
+  searchPlaceholder="Governance, valuation, due diligence"
   tagline={TAGLINE}
   logoSrc={LOGO_SRC}
   ctaText="Get Started"

--- a/sites/meridian-advisory.com/src/pages/about.astro
+++ b/sites/meridian-advisory.com/src/pages/about.astro
@@ -117,6 +117,8 @@ const faqItems = [
   {contactInfo}
   {socialLinks}
   siteName={SITE_NAME}
+  search
+  searchPlaceholder="Governance, valuation, due diligence"
   tagline={TAGLINE}
   logoSrc={LOGO_SRC}
   ctaText="Request a briefing"

--- a/sites/meridian-advisory.com/src/pages/contact.astro
+++ b/sites/meridian-advisory.com/src/pages/contact.astro
@@ -25,6 +25,8 @@ const offices = [
   {contactInfo}
   {socialLinks}
   siteName={SITE_NAME}
+  search
+  searchPlaceholder="Governance, valuation, due diligence"
   tagline={TAGLINE}
   logoSrc={LOGO_SRC}
   ctaText="Request a briefing"

--- a/sites/meridian-advisory.com/src/pages/index.astro
+++ b/sites/meridian-advisory.com/src/pages/index.astro
@@ -66,6 +66,8 @@ const insights = [
   {contactInfo}
   {socialLinks}
   siteName={SITE_NAME}
+  search
+  searchPlaceholder="Governance, valuation, due diligence"
   tagline={TAGLINE}
   logoSrc={LOGO_SRC}
   ctaText="Request a briefing"

--- a/sites/meridian-advisory.com/src/pages/services.astro
+++ b/sites/meridian-advisory.com/src/pages/services.astro
@@ -70,6 +70,8 @@ const practices = [
   {contactInfo}
   {socialLinks}
   siteName={SITE_NAME}
+  search
+  searchPlaceholder="Governance, valuation, due diligence"
   tagline={TAGLINE}
   logoSrc={LOGO_SRC}
   ctaText="Request a briefing"


### PR DESCRIPTION
## Search

Extracted from a production site rather than written for the starter, so it arrives having already survived a real thirty-eight page site.

**`packages/shared-ui/scripts/search-index.mjs`** builds the index from the HTML that actually shipped, so a page whose copy changed cannot then be missing from search, and a page that never rendered cannot appear in it. Skips `noindex` pages and the 404: if it is not for search engines it is not for the reader either. Takes `--dist`, `--public`, `--exclude` and `--body`.

**`packages/shared-ui/src/components/SiteSearch.astro`** is a dialog, not a page. The index is fetched on first use and never on load, so search costs nothing on the critical path. Every token must match, and results rank by *where* the match is: a word in the heading outranks the same word in the ninth paragraph. Keyboard throughout, and focus returns to the control that opened it.

Deliberately **not** a search library. A WebAssembly runtime with its own index format earns its size at a few thousand pages; on a forty-page marketing site it would be most of the JavaScript on the page. The index runs about 1.8 KB gzipped per page.

**Off by default**, and that is the important part: it needs the generator in the build script, and a search box without an index returns nothing at all, silently. The docs put both steps together for that reason.

Every CSS rule is wrapped in `:where()`, so it scores zero specificity and a site's own stylesheet always wins with no `!important` anywhere. Nine custom properties restyle the whole panel. Sizes are literal pixels: search chrome is interface, and reaching for a display-scale token sets a result title at 49px.

Wired through `Header` and `BaseLayout`, and turned on in Meridian so the example in the docs is one that actually runs.

## Showcase

Added `edubold.com`, `moiengineering.com`, `hybridagrobots.com` and `indivar.com`. Every URL in that list was requested and returned 200, including the three existing entries and all three `pages.dev` demos.

## Verification

- Meridian builds and indexes: 8 pages, 11.8 KB
- Search control present in the shipped HTML
- Ranking checked on the source site: "professional tax" returns the payroll post, then `/compliance/`, then `/pay-your-staff/`
- Keyboard verified: `/` and Cmd-K open, arrows move, Enter follows, Escape closes and restores focus