### PR TITLE
docs: changelog, restructured README, and v2.3.0 version bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,198 @@
+# Changelog
+
+All notable changes to Astro Fleet are recorded here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the
+project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Two version numbers move independently:
+
+- **Astro Fleet** — the template and shared packages. Tagged `vX.Y.Z`.
+- **`create-astro-fleet`** — the scaffolding CLI, published to npm.
+
+The CLI pins the template it clones to a specific Fleet tag, so a Fleet release
+that changes the template needs a matching CLI release. If it does not get one,
+new projects silently scaffold from the previous version.
+
+---
+
+## [2.3.0] — 2026-08-23
+
+Two shared components and a documentation set built to be executed rather than
+read.
+
+### Added
+
+- **`SiteSearch`** — search across every page, with no server and no search
+  service. The index is generated from the HTML that actually shipped, so a page
+  whose copy changed cannot go missing from search and a page that never
+  rendered cannot appear in it. Fetched on first use and never on load, about
+  1.8 KB gzipped per page. `noindex` pages and the 404 are skipped. Keyboard
+  throughout: `/` or Cmd/Ctrl-K opens, arrows move, Enter follows, Escape closes
+  and returns focus to the control that opened it.
+
+  Deliberately not a search library. A WebAssembly runtime with its own index
+  format earns its size at a few thousand pages; on a forty-page marketing site
+  it would be most of the JavaScript on the page.
+
+- **`packages/shared-ui/scripts/search-index.mjs`** — the index generator. Takes
+  `--dist`, `--public`, `--exclude` and `--body`. Runs after `astro build`.
+
+- **`Analytics`** — GA4 behind a consent banner, wired through `BaseLayout` as
+  `gaId` and `privacyHref`. Two props is the whole integration.
+
+  Stricter than the usual Consent Mode v2 pattern, deliberately. The common
+  approach loads `gtag.js` immediately with `analytics_storage: denied` and
+  flips it later, which still fetches Google's script and still pings before
+  anybody has agreed. Most privacy policies do not describe that. This one keeps
+  the sentence they do use: nothing is requested from googletagmanager.com until
+  the visitor accepts. Consent Mode defaults are still set before the script
+  arrives, because a granted signal needs something to update.
+
+  Global Privacy Control is read as a decline. The choice lives in
+  `localStorage`, shared across an origin so nobody is asked twice.
+  `window.track(name, params)` is available everywhere and is a no-op until
+  consent, so callers never have to check. `requireConsent={false}` restores the
+  standard behaviour for anyone who wants it.
+
+- **`docs/build-a-site-with-claude.md`** — clone to live domain with Claude
+  Code, with the exact sentences to type at each step, a troubleshooting
+  section, and an honest list of what this repo does not do.
+
+- **`CHANGELOG.md`** — this file. Earlier versions reconstructed from the
+  published GitHub releases.
+
+### Changed
+
+- **`CLAUDE.md` rewritten** from a 108-line reference into an operating manual.
+  It now carries the whole path: prerequisites with the checks to actually run,
+  the five questions to ask in one message and the longer list not to ask about,
+  scaffolding, design direction including the generic looks to avoid, copy
+  rules, each feature and how to switch it on, deployment down to the individual
+  DNS record, and a verification checklist that insists on numbers rather than
+  adjectives.
+
+  Its section 9 lists nine failure modes that have shipped silently in real
+  projects. None of them produce an error: an undefined CSS custom property
+  deleting a whole declaration, a reset outranking the flow rhythm, a descendant
+  selector repainting a component, `getStaticPaths` not seeing its own
+  frontmatter, a redirect splat shadowing real routes, search returning nothing
+  in development, a `nowrap` column holding prose, trailing-slash mismatches in
+  redirects, and Cloudflare rewriting email addresses out of the served HTML.
+
+- **`BaseLayout`** takes four new optional props: `search`, `searchPlaceholder`,
+  `gaId`, `privacyHref`. All features are off by default.
+
+- **`Header`** takes `search` and `searchPlaceholder`, and renders the search
+  control only when asked.
+
+- **Showcase** in the README now lists seven production sites, each checked live
+  and returning 200 on the day of release: edubold.com, moiengineering.com,
+  hybridagrobots.com, indivar.com, stakteck.com, vairi.com, claspt.app.
+
+- **`docs/components.md`** documents both new components in full, including the
+  nine CSS custom properties that restyle the search panel and the seven that
+  restyle the consent bar.
+
+### Fixed
+
+- **Analytics no longer ships its script to sites that do not use it.** It is
+  rendered conditionally in `BaseLayout`, so a site with no `gaId` carries
+  none of it. Measured at 1.4 KB per page on the two demo sites that leave it
+  off.
+
+- **Component count corrected** across four files. The README said 22,
+  `docs/components.md` said 22, `docs/framework-integrations.md` said 22 twice.
+  The real count is 24.
+
+- **Duplicate `### Analytics` heading** in `docs/components.md` produced an
+  ambiguous anchor, and the older of the two recommended pasting a raw `gtag`
+  snippet, which contradicts the new component. It is now
+  "Other analytics providers" and points at the built-in.
+
+- **Root `package.json` version** was stuck at `1.0.0` while the repository was
+  tagged `v2.2.0`. It now tracks the tag.
+
+---
+
+## [2.2.0] — 2026-04-17
+
+### Added
+
+- **`create-astro-fleet` CLI** — scaffold a new fleet, or add a site to an
+  existing one, without cloning the repo. `bunx create-astro-fleet`.
+- **Keystatic CMS example** in the Meridian demo, with the access-control
+  caveats documented.
+- **SEO hardening** — P0 meta fixes, automatic JSON-LD, security headers, RSS,
+  and `docs/seo-recipes.md` covering per-page OG images, git-based sitemap
+  `lastmod`, `llms.txt`, IndexNow, markdown alternates and build-time
+  validation.
+
+### Changed
+
+- CLI install flow detects the package manager from `npm_config_user_agent`
+  (bun, pnpm, yarn, npm) and offers to install after scaffolding.
+- CLI pins its default template to a Fleet tag via a `TEMPLATE_VERSION`
+  constant.
+
+### Fixed
+
+- CLI flag parser treats `--no-*` and known boolean flags as pure booleans.
+  Previously `--no-install` consumed the next positional argument.
+
+---
+
+## [2.1.0] — 2026-04-16
+
+### Added
+
+- `docs/framework-integrations.md` — adding React, Vue or Svelte islands,
+  Islands Architecture, View Transitions and Content Collections.
+- Astro capabilities reference.
+
+### Changed
+
+- Node 22 is now the documented requirement.
+
+---
+
+## [2.0.0] — 2026-04-16
+
+### Changed
+
+- **Upgraded to Astro 6**, with self-hosted fonts via the Astro Fonts API. No
+  third-party font requests at runtime.
+
+### Added
+
+- CI badges and promotion drafts.
+
+---
+
+## [1.1.0] — 2026-04-16
+
+### Added
+
+- 12 further shared components, bringing the set to 22, each with full
+  documentation.
+- CI workflow and pull request template.
+
+### Changed
+
+- Comprehensive documentation rewrite, and all components integrated into the
+  three demo sites.
+
+---
+
+## [1.0.0] — 2026-04-15
+
+Initial release. Multi-site Astro monorepo with shared components, a design
+token system with three presets, three demo sites, scaffolding scripts and
+infrastructure templates. MIT licensed.
+
+[2.3.0]: https://github.com/Indivar/astro-fleet/compare/v2.2.0...v2.3.0
+[2.2.0]: https://github.com/Indivar/astro-fleet/compare/v2.1.0...v2.2.0
+[2.1.0]: https://github.com/Indivar/astro-fleet/compare/v2.0.0...v2.1.0
+[2.0.0]: https://github.com/Indivar/astro-fleet/compare/v1.1.0...v2.0.0
+[1.1.0]: https://github.com/Indivar/astro-fleet/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/Indivar/astro-fleet/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -2,17 +2,185 @@
 
 [![CI](https://github.com/Indivar/astro-fleet/actions/workflows/ci.yml/badge.svg)](https://github.com/Indivar/astro-fleet/actions/workflows/ci.yml) [![GitHub release](https://img.shields.io/github/v/release/Indivar/astro-fleet)](https://github.com/Indivar/astro-fleet/releases) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-One codebase, many sites. A multi-site Astro monorepo starter for agencies and multi-brand companies.
+**One codebase, many sites.** A multi-site Astro monorepo for agencies and
+multi-brand companies.
 
-Astro Fleet gives you a production-ready monorepo with shared components, per-site design tokens, Turborepo build orchestration, and deployment to Cloudflare Pages, Vercel, or a self-hosted VPS. Create a new site in one command. Brand it with a design preset. Deploy it independently.
+Shared components, per-site design tokens, Turborepo builds, and independent
+deployment to Cloudflare Pages, Vercel or your own VPS. Create a site in one
+command, brand it with a preset, ship it on its own domain.
 
-**Built for AI-driven development.** Astro Fleet's project structure, typed component props, and clear configuration patterns are optimized for AI coding assistants. Tested extensively with [Claude Code](https://claude.ai/claude-code). Also works with Gemini CLI and other AI coding tools. [See the AI Workflow Guide →](docs/ai-workflow.md)
+Site-wide search, consent-gated analytics and full SEO are built in and **off by
+default** — each is one instruction away.
 
-## Live Demos
+**Built for AI-driven development.** The structure, typed props and single-file
+site config exist so an AI assistant can work in this repo without guessing.
+Tested extensively with [Claude Code](https://claude.ai/claude-code); works with
+Gemini CLI and others.
 
-Three fully-built sites — same monorepo, same shared components, three completely different looks and feels. Each demo is a separate site under `sites/` with its own navigation, content, and design preset.
+---
 
-| Preset | Demo | Use Case | Live |
+## Get started
+
+### With Claude Code
+
+The fastest path from nothing to a live site:
+
+```bash
+git clone https://github.com/Indivar/astro-fleet.git
+cd astro-fleet
+bun install
+claude
+```
+
+Then say what you want:
+
+> Build me a site for acme.com. We fabricate structural steel for commercial
+> builders in Auckland. The buyer is a project manager comparing fabricators on
+> lead time and certification. I want them to request a quote.
+
+Claude reads [`CLAUDE.md`](CLAUDE.md) automatically and follows the whole
+process: scaffold, design, content, SEO, deploy.
+**[Build a site with Claude →](docs/build-a-site-with-claude.md)** is the
+human-readable walkthrough, with the exact sentences to type at each step.
+
+### With the CLI
+
+```bash
+bunx create-astro-fleet         # or: npm create astro-fleet
+cd my-astro-fleet
+bun install
+bun run dev
+```
+
+Prompts for a target directory, first-site domain and design preset. Use
+`--domain` and `--preset` to skip them.
+
+### By hand
+
+```bash
+git clone https://github.com/Indivar/astro-fleet.git
+cd astro-fleet
+bun install
+bun run dev          # starter site at localhost:4321
+```
+
+**Requires** Bun 1.1+ and Node 20+. A Cloudflare account is needed only to
+deploy, and it is free.
+
+---
+
+## Everyday commands
+
+```bash
+# Develop
+bun run dev                                    # every site (4321)
+bun run dev --filter=acme.com                  # one site
+bun run dev --filter=acme.com -- --port 4322   # a second alongside
+
+# Build
+bun run build                                  # all, in parallel
+bun run build --filter=acme.com                # one
+
+# Typecheck and lint
+bun run lint
+
+# Add a site
+bunx create-astro-fleet add acme.com saas      # or:
+./scripts/new-site.sh acme.com saas
+bun install                                     # always, after adding
+
+# Deploy
+npx wrangler pages deploy sites/acme.com/dist \
+  --project-name=acme-com --branch=main
+
+# Self-hosted infrastructure
+./scripts/setup-infra.sh acme.com,other.com
+```
+
+---
+
+## Turning features on
+
+Everything is opt-in. Full detail in
+[`CLAUDE.md`](CLAUDE.md) §6 and the [components reference](docs/components.md).
+
+### Site search
+
+Add the index generator to the site's build, then switch it on:
+
+```jsonc
+// package.json
+"build": "astro build && node ../../packages/shared-ui/scripts/search-index.mjs"
+```
+
+```astro
+<BaseLayout search searchPlaceholder="Pricing, integrations, security" ...>
+```
+
+Built from the HTML that actually shipped, fetched on first use and never on
+load, about 1.8 KB gzipped per page. `/` or Cmd-K opens it. No search service,
+no server, no subscription.
+
+### Analytics, behind consent
+
+```astro
+<BaseLayout gaId="G-XXXXXXXXXX" privacyHref="/privacy/" ...>
+```
+
+That is the whole integration. **Nothing is requested from Google until the
+visitor accepts** — stricter than the usual Consent Mode v2 pattern, which
+loads the script immediately with tracking denied. Global Privacy Control is
+read as a decline. `requireConsent={false}` restores standard behaviour.
+
+Your numbers will be lower than a site that tags everyone. They will also match
+what your privacy page says.
+
+### SEO
+
+Automatic once `site` is set in `astro.config.mjs`: per-page titles and
+descriptions, canonicals, Open Graph, Twitter cards, JSON-LD, sitemap.
+[SEO Recipes](docs/seo-recipes.md) covers the rest — per-page OG images,
+git-based `lastmod`, `llms.txt` for answer engines, IndexNow, fuzzy 404
+redirects and build-time validation.
+
+---
+
+## What's included
+
+- **24 shared components + 3 layouts** — header, footer, SEO head, CTA blocks,
+  cards, forms, testimonials, breadcrumbs, pricing tables, FAQ accordions, team
+  grids, timelines, hero sliders, section dividers, comparison tables, search
+  and analytics. Typed props, CSS-variable theming, zero JS unless a component
+  needs it.
+- **Design token system** — three presets (Corporate, SaaS, Warm) behind a
+  TypeScript interface. Change colours and fonts per site without touching
+  component code.
+- **Site scaffolder** — `bunx create-astro-fleet` or `./scripts/new-site.sh`,
+  wiring config, styles and the build pipeline.
+- **Search and analytics**, as above.
+- **CMS-ready** — the Meridian demo ships with [Keystatic](https://keystatic.com);
+  admin at `/keystatic` in dev, content committed as markdown.
+  [Adding a CMS](docs/adding-a-cms.md) covers the pattern and the alternatives.
+- **Self-hosted fonts** — the Astro Fonts API downloads at build time and serves
+  from your domain. No runtime third-party requests.
+- **Framework-agnostic** — native `.astro` files throughout. Add React, Vue,
+  Svelte, Solid or Preact to any site via Astro's
+  [Islands Architecture](https://docs.astro.build/en/concepts/islands/).
+- **Infrastructure templates** — optional Docker Compose + Traefik + Caddy for
+  self-hosting.
+- **An AI operating manual** — [`CLAUDE.md`](CLAUDE.md) carries the whole path
+  from prerequisites to DNS, including nine failure modes that ship silently in
+  real projects.
+
+---
+
+## Live demos
+
+Three fully-built sites. Same monorepo, same shared components, three
+genuinely different looks — the presets are complete site personalities, not
+colour swaps.
+
+| Preset | Demo | Use case | Live |
 |---|---|---|---|
 | **Corporate** | [Meridian Advisory](sites/meridian-advisory.com) | Management consulting firm | [astro-fleet-meridian.pages.dev](https://astro-fleet-meridian.pages.dev) |
 | **SaaS** | [Flux Analytics](sites/flux-analytics.com) | Developer-tool product site | [astro-fleet-flux.pages.dev](https://astro-fleet-flux.pages.dev) |
@@ -41,93 +209,65 @@ Three fully-built sites — same monorepo, same shared components, three complet
   </tr>
 </table>
 
-Each demo composes the **same shared components** (`Header`, `Footer`, `ServiceCard`, `ContactForm`, `CTABlock`, `Breadcrumb`) — but the navigation, section structure, hero layouts, and typography are all unique to the brand. The presets aren't colour-swap reskins; they're complete site personalities.
+Each composes the **same shared components**. The navigation, section structure,
+hero layouts and typography are unique to each brand.
+
+---
 
 ## Built with Astro Fleet
 
-Real sites running in production on the same codebase as the demos above:
+Real sites running in production on this codebase:
 
-- **[edubold.com](https://www.edubold.com)** — School management ERP for Indian schools and trusts: admissions, fees, payroll, and double-entry accounts on one set of records
+- **[edubold.com](https://www.edubold.com)** — School management ERP for Indian schools and trusts: admissions, fees, payroll and double-entry accounts on one set of records
 - **[moiengineering.com](https://www.moiengineering.com)** — Packaging and wrapping machinery, and a parts catalogue going back to 1960 (Mohali, India)
 - **[hybridagrobots.com](https://www.hybridagrobots.com)** — Computer-vision grading and sorting machines for agriculture and poultry
-- **[indivar.com](https://www.indivar.com)** — Independent technology consulting: architecture, cloud, and delivery
-- **[stakteck.com](https://www.stakteck.com)** — IT staffing, contract hiring, and staff augmentation across India
+- **[indivar.com](https://www.indivar.com)** — Independent technology consulting: architecture, cloud and delivery
+- **[stakteck.com](https://www.stakteck.com)** — IT staffing, contract hiring and staff augmentation across India
 - **[vairi.com](https://www.vairi.com)** — AI-enhanced software development and business automation consultancy (Auckland, NZ)
-- **[claspt.app](https://www.claspt.app)** — Encrypted markdown notes and password vault, on the Microsoft Store, macOS, and Linux
+- **[claspt.app](https://www.claspt.app)** — Encrypted markdown notes and password vault, on the Microsoft Store, macOS and Linux
 
 Every URL above was checked and returned 200 on 22 August 2026.
 
-_More coming soon._ If you ship a site with Astro Fleet, open a PR adding it here — we'd love to feature it.
+If you ship a site with Astro Fleet, open a PR adding it here.
 
-## Quick Start
-
-**Building with Claude Code?** Clone the repo and read
-[Build a site with Claude](docs/build-a-site-with-claude.md). It walks from
-`git clone` to a live domain, with the exact things to type at each step.
-`CLAUDE.md` is the agent's copy of the same process, and Claude reads it
-automatically.
-
-**The fastest way — scaffold a new fleet with the CLI:**
-
-```bash
-bunx create-astro-fleet         # or: npm create astro-fleet
-cd my-astro-fleet
-bun install
-bun run dev
-```
-
-The CLI prompts for a target directory, first-site domain, and design preset. Use `--domain` / `--preset` flags to skip prompts.
-
-**Or clone this repo directly:**
-
-```bash
-git clone https://github.com/indivar/astro-fleet.git
-cd astro-fleet
-bun install
-bun run dev          # → starter site at localhost:4321
-```
-
-Add more sites to an existing fleet:
-
-```bash
-bunx create-astro-fleet add yourdomain.com saas
-# or the equivalent bash:
-./scripts/new-site.sh yourdomain.com saas
-bun install
-```
-
-## What's Included
-
-- **24 shared components + 3 layouts** — Header, Footer, SEO Head, CTA blocks, cards, forms, testimonials, breadcrumbs, pricing tables, FAQ accordions, team grids, timelines, hero sliders, section dividers, comparison tables, and more. All accept content via typed props, all use CSS variables for theming.
-- **Design token system** — 3 presets (Corporate, SaaS, Warm) with a TypeScript interface. Create custom presets or modify colors and fonts per site without touching component code.
-- **Site scaffolder** — Either `bunx create-astro-fleet` (cross-platform, interactive prompts) or `./scripts/new-site.sh domain.com [preset]` (bash) creates a new site from the starter template with the correct config, styles, and build pipeline wired up.
-- **CMS-ready** — Meridian demo ships with [Keystatic](https://keystatic.com) wired up for editable content. Admin at `/keystatic` in dev, content committed as markdown. See [Adding a CMS](docs/adding-a-cms.md) for the pattern and alternatives.
-- **Infrastructure templates** — Optional Docker Compose + Traefik + Caddy setup for self-hosting on a VPS. Run `./scripts/setup-infra.sh` to generate configs for your domains.
-- **Framework-agnostic** — All components are native `.astro` files (zero JS by default). Need interactivity? Add React, Vue, Svelte, Solid, or Preact to any site — Astro's [Islands Architecture](https://docs.astro.build/en/concepts/islands/) hydrates only the interactive parts.
-- **Self-hosted fonts** — Astro 6 Fonts API downloads Google Fonts at build time and serves them from your domain. No runtime requests to third-party servers, better privacy, optimized fallbacks.
-- **AI-first workflow** — Designed to be developed with Claude Code, Gemini CLI, or any AI coding assistant. Sample prompts and patterns in the [AI Workflow Guide](docs/ai-workflow.md).
+---
 
 ## Documentation
 
-- [Build a site with Claude](docs/build-a-site-with-claude.md) — Clone to live domain with Claude Code, step by step
-- [Getting Started](docs/getting-started.md) — Clone to first deploy in 15 minutes
-- [Adding a Site](docs/adding-a-site.md) — Create and configure additional sites
-- [Adding a CMS](docs/adding-a-cms.md) — Keystatic pattern used in Meridian, plus when to pick a different CMS
-- [SEO Recipes](docs/seo-recipes.md) — Optional SEO add-ons (per-page OG images, git-based lastmod, llms.txt, IndexNow, view transitions, and more)
-- [Components Reference](docs/components.md) — Props, usage examples, CSS variables for every component
-- [Design Tokens](docs/design-tokens.md) — Branding system, presets, custom palettes
-- [Framework Integrations](docs/framework-integrations.md) — Add React/Vue/Svelte, Islands Architecture, View Transitions, Content Collections, and more
-- [Deployment](docs/deployment.md) — Cloudflare Pages, Vercel, Netlify, or self-hosted
-- [AI Workflow](docs/ai-workflow.md) — Sample prompts, tool setup, AI-driven development patterns
+**Start here**
+
+- [Build a site with Claude](docs/build-a-site-with-claude.md) — clone to live domain, step by step
+- [Getting Started](docs/getting-started.md) — clone to first deploy in 15 minutes
+- [`CLAUDE.md`](CLAUDE.md) — the operating manual Claude reads. Worth reading yourself
+
+**Building**
+
+- [Adding a Site](docs/adding-a-site.md) — create and configure additional sites
+- [Components Reference](docs/components.md) — props, examples and CSS variables for all 24
+- [Design Tokens](docs/design-tokens.md) — presets and custom palettes
+- [Framework Integrations](docs/framework-integrations.md) — React, Vue, Svelte, islands, view transitions
+- [Adding a CMS](docs/adding-a-cms.md) — the Keystatic pattern, and when to pick something else
+
+**Shipping**
+
+- [SEO Recipes](docs/seo-recipes.md) — OG images, `llms.txt`, IndexNow, validation
+- [Deployment](docs/deployment.md) — Cloudflare Pages, Vercel, Netlify, self-hosted
+- [AI Workflow](docs/ai-workflow.md) — prompts, tool setup, AI-driven patterns
+- [Changelog](CHANGELOG.md) — what changed, and when
+
+---
 
 ## Stack
 
-Astro 6 · Bun · Turborepo 2 · Tailwind CSS 4 · TypeScript · Static-first (zero JS by default) · Works with React, Vue, Svelte, Solid, Preact
+Astro 6 · Bun · Turborepo 2 · Tailwind CSS 4 · TypeScript · static-first, zero JS
+by default · works with React, Vue, Svelte, Solid and Preact
 
 ## License
 
-MIT — use it for anything. See [LICENSE](LICENSE).
+MIT. Use it for anything. See [LICENSE](LICENSE).
 
 ## Credits
 
-Built by [Indivar Software Solutions](https://indivar.com), a software company based in India and New Zealand. We use Astro Fleet to run our own portfolio of company websites.
+Built by [Indivar Software Solutions](https://indivar.com), a software company
+in India and New Zealand. We use Astro Fleet to run our own portfolio of company
+websites — the seven listed above.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-fleet",
-  "version": "1.0.0",
+  "version": "2.3.0",
   "private": true,
   "description": "Multi-site Astro monorepo starter for agencies and multi-brand companies",
   "license": "MIT",

--- a/packages/create-astro-fleet/README.md
+++ b/packages/create-astro-fleet/README.md
@@ -42,7 +42,7 @@ bunx create-astro-fleet ./my-fleet --domain acme.com --preset saas
 
 ### `init`
 
-- `--template <source>` — giget source, default `github:indivar/astro-fleet#v2.2.0` (pinned to a specific fleet release tag; bumped inside the CLI when a new template ships)
+- `--template <source>` — giget source, default `github:indivar/astro-fleet#v2.3.0` (pinned to a specific fleet release tag; bumped inside the CLI when a new template ships)
 - `--domain <name>` — skip the first-site domain prompt
 - `--preset <name>` — skip the preset prompt
 - `--keep-demos` — keep the three demo sites as reference

--- a/packages/create-astro-fleet/package.json
+++ b/packages/create-astro-fleet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-astro-fleet",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Scaffold a new Astro Fleet monorepo or add a site to an existing one.",
   "license": "MIT",
   "author": "Varinder Singh (https://github.com/indivar)",

--- a/packages/create-astro-fleet/src/help.mjs
+++ b/packages/create-astro-fleet/src/help.mjs
@@ -15,7 +15,7 @@ ${pc.bold('Commands:')}
   help                      Show this help
 
 ${pc.bold('Options (init):')}
-  --template <source>       giget template source (default: github:indivar/astro-fleet#v2.2.0)
+  --template <source>       giget template source (default: github:indivar/astro-fleet#v2.3.0)
   --preset <name>           corporate | saas | warm (skips prompt)
   --domain <name>           first site domain (skips prompt)
   --keep-demos              keep the three demo sites as reference

--- a/packages/create-astro-fleet/src/init.mjs
+++ b/packages/create-astro-fleet/src/init.mjs
@@ -10,7 +10,7 @@ import { scaffoldSite } from './scaffold.mjs';
 // The fleet template release this CLI ships with.
 // Bump to match the latest https://github.com/indivar/astro-fleet/releases tag
 // when you cut a new template release.
-const TEMPLATE_VERSION = 'v2.2.0';
+const TEMPLATE_VERSION = 'v2.3.0';
 const DEFAULT_TEMPLATE = `github:indivar/astro-fleet#${TEMPLATE_VERSION}`;
 
 const DEMO_SITES = ['flux-analytics.com', 'meridian-advisory.com', 'olive-and-vine.com'];


### PR DESCRIPTION
Release prep for **v2.3.0**.

## `CHANGELOG.md`

Did not exist. Earlier versions are reconstructed from the published GitHub
releases rather than invented, so the history is accurate back to v1.0.0.

It also records the rule that bit during this prep: **the CLI pins the template
it clones to a Fleet tag**, so a Fleet release that changes the template needs a
matching CLI release, or new projects silently scaffold from the old one.

## README, reordered

It now answers questions in the order a reader has them:

**what this is → how to start → the commands → how to switch each feature on →
the demos → the docs**

Getting started previously sat below three screens of screenshots. Search,
analytics and SEO now have their own section with the exact code to add, and the
documentation list is grouped into *start here*, *building* and *shipping*.

## Versions — all three had to move together

| | from | to |
|---|---|---|
| `astro-fleet` | `1.0.0` | `2.3.0` |
| `create-astro-fleet` | `0.1.0` | `0.2.0` |
| `TEMPLATE_VERSION` | `v2.2.0` | `v2.3.0` |

The root `package.json` had been stuck at `1.0.0` since the repo was tagged
`v2.2.0`.

`TEMPLATE_VERSION` is the one that matters. Miss it and `bunx create-astro-fleet`
keeps cloning v2.2.0, so **every new project ships without search or analytics
while the docs describe both**. Two further references to the old tag — in
`help.mjs` and the CLI README — would have told users the wrong default. Both
updated, and verified by running the CLI's `--help` and reading the line back.

## Checked

- Every internal README link resolves (0 broken)
- All 9 screenshots present
- `bun run build` green across all four sites