### PR TITLE
docs: release checklist, so the CLI publish is never skipped again

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,3 +76,7 @@ chore: upgrade Astro to 5.3
 ## Questions
 
 For general questions about using Astro Fleet, use [GitHub Discussions](https://github.com/indivar/astro-fleet/discussions). Issues are for bugs and confirmed feature requests only.
+
+## Releasing
+
+See [docs/releasing.md](docs/releasing.md). The template tag and the `create-astro-fleet` npm package ship together; a release without the CLI publish leaves new projects on the old template.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Astro Fleet
 
-[![CI](https://github.com/Indivar/astro-fleet/actions/workflows/ci.yml/badge.svg)](https://github.com/Indivar/astro-fleet/actions/workflows/ci.yml) [![GitHub release](https://img.shields.io/github/v/release/Indivar/astro-fleet)](https://github.com/Indivar/astro-fleet/releases) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![CI](https://github.com/Indivar/astro-fleet/actions/workflows/ci.yml/badge.svg)](https://github.com/Indivar/astro-fleet/actions/workflows/ci.yml) [![GitHub release](https://img.shields.io/github/v/release/Indivar/astro-fleet)](https://github.com/Indivar/astro-fleet/releases) [![npm](https://img.shields.io/npm/v/create-astro-fleet)](https://www.npmjs.com/package/create-astro-fleet) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 **One codebase, many sites.** A multi-site Astro monorepo for agencies and
 multi-brand companies.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,45 @@
+# Releasing Astro Fleet
+
+Two things ship together, and forgetting the second one is the mistake this
+page exists to prevent:
+
+1. **The template** (this repo), tagged `vX.Y.Z` on GitHub.
+2. **`create-astro-fleet`** on npm, which pins the template tag it clones.
+   If the CLI is not republished, `npm create astro-fleet` keeps scaffolding
+   the previous version and nobody notices.
+
+## Checklist
+
+1. **Changelog.** Add `## [X.Y.Z] — YYYY-MM-DD` to `CHANGELOG.md` in the
+   existing style (Added / Changed / Fixed, plain language, no em dashes).
+2. **Versions.** Bump the root `package.json`; `packages/shared-ui` if it
+   changed; `packages/create-astro-fleet` to its next version and set
+   `TEMPLATE_VERSION = 'vX.Y.Z'` in `src/init.mjs` and the default shown in
+   `src/help.mjs`.
+3. **Verify.** `bun install`, `bun run build` (every site), `bun run lint`,
+   `python3 scripts/responsive-images.py --check`,
+   `python3 scripts/localize-stock-images.py --check`. Grep the diff for
+   anything that belongs to a private site (client names, ids, tokens).
+4. **PR.** Branch, commit, push, open a PR, wait for the `Build all sites`
+   check, squash-merge.
+5. **Tag and release.** On `main`:
+   `git tag -a vX.Y.Z -m "..." && git push origin vX.Y.Z`, then
+   `gh release create vX.Y.Z --title "..." --notes-file <changelog section>`.
+6. **Publish the CLI.** From `packages/create-astro-fleet`, in your own
+   terminal (npm opens the browser for the passkey; it cannot be done from an
+   agent session):
+   ```
+   npm publish
+   ```
+   Confirm with `npm view create-astro-fleet version`. Then add one line to
+   the GitHub release notes: "`create-astro-fleet@A.B.C` is on npm, pinned to
+   this tag."
+7. **Tell the private fleet.** If the change came from a production site,
+   record the backport in that project's memory so it is not ported twice.
+
+## Why the CLI is published by hand
+
+The npm account uses a passkey for two-factor. `npm publish` prompts through
+the browser, which only works in an interactive terminal. A granular access
+token with "bypass 2FA" would allow automation; until one exists, step 6 is a
+person.


### PR DESCRIPTION
Adds docs/releasing.md (template tag + create-astro-fleet publish ship together), an npm badge, and a CONTRIBUTING pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)